### PR TITLE
fix: resolve VAD getting stuck after extended conversations

### DIFF
--- a/videosdk-agents/videosdk/agents/speech_understanding.py
+++ b/videosdk-agents/videosdk/agents/speech_understanding.py
@@ -115,14 +115,22 @@ class SpeechUnderstanding(EventEmitter[Literal["transcript_interim", "transcript
 
             if self.denoise:
                 audio_data = await self.denoise.denoise(audio_data)
-            
+
+            tasks = []
             if self.stt:
-                async with self.stt_lock:
-                    await self.stt.process_audio(audio_data)
-            
+                async def _stt_process():
+                    async with self.stt_lock:
+                        await self.stt.process_audio(audio_data)
+                tasks.append(_stt_process())
             if self.vad:
-                await self.vad.process_audio(audio_data)
-                
+                tasks.append(self.vad.process_audio(audio_data))
+
+            if tasks:
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+                for r in results:
+                    if isinstance(r, Exception):
+                        logger.error(f"Audio processing component failed: {r}")
+
         except Exception as e:
             logger.error(f"Audio processing failed: {str(e)}")
             self.emit("error", f"Audio processing failed: {str(e)}")
@@ -380,7 +388,13 @@ class SpeechUnderstanding(EventEmitter[Literal["transcript_interim", "transcript
         self._accumulated_transcript = ""
         self._waiting_for_more_speech = False
         self._preemptive_transcript = None
-        
+
+        if self.vad:
+            try:
+                await self.vad.flush()
+            except Exception as e:
+                logger.error(f"Error flushing VAD: {e}")
+
         self.stt = None
         self.vad = None
         self.turn_detector = None

--- a/videosdk-agents/videosdk/agents/vad.py
+++ b/videosdk-agents/videosdk/agents/vad.py
@@ -77,6 +77,10 @@ class VAD(EventEmitter[Literal["error", "info"]]):
         """
         raise NotImplementedError
 
+    async def flush(self) -> None:
+        """Signal that no more audio will arrive. Subclasses may override."""
+        pass
+
     async def aclose(self) -> None:
         """Cleanup resources"""
         logger.info(f"Cleaning up VAD: {self.label}")

--- a/videosdk-plugins/videosdk-plugins-silero/videosdk/plugins/silero/onnx_runtime.py
+++ b/videosdk-plugins/videosdk-plugins-silero/videosdk/plugins/silero/onnx_runtime.py
@@ -1,13 +1,26 @@
 import importlib.resources
 import atexit
+import os
+import logging
+import urllib.request
 import numpy as np
-import onnxruntime  
+import onnxruntime
 from contextlib import ExitStack
-_resource_files = ExitStack()
+from pathlib import Path
 
+_resource_files = ExitStack()
 atexit.register(_resource_files.close)
 
+logger = logging.getLogger(__name__)
+
+_MODEL_DOWNLOAD_URL = (
+    "https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx"
+)
+_CACHE_DIR = Path.home() / ".cache" / "videosdk" / "silero"
+
 SAMPLE_RATES = [8000, 16000]
+
+
 class VadModelWrapper:
     def __init__(self, *, session: onnxruntime.InferenceSession, rate: int) -> None:
         if rate not in SAMPLE_RATES:
@@ -68,21 +81,28 @@ class VadModelWrapper:
     
     @staticmethod
     def create_inference_session(use_cpu_only: bool) -> onnxruntime.InferenceSession:
-        model_path = importlib.resources.files("videosdk.plugins.silero.model") / "silero_vad.onnx"
-        with importlib.resources.as_file(model_path) as temp_path:
-            session_opts = onnxruntime.SessionOptions()
-            session_opts.inter_op_num_threads = 1
-            session_opts.intra_op_num_threads = 1
-            session_opts.execution_mode = onnxruntime.ExecutionMode.ORT_SEQUENTIAL
+        session_opts = onnxruntime.SessionOptions()
+        session_opts.inter_op_num_threads = 1
+        session_opts.intra_op_num_threads = 1
+        session_opts.execution_mode = onnxruntime.ExecutionMode.ORT_SEQUENTIAL
 
-            providers = (
-                ["CPUExecutionProvider"]
-                if use_cpu_only and "CPUExecutionProvider" in onnxruntime.get_available_providers()
-                else None
-            )
+        providers = (
+            ["CPUExecutionProvider"]
+            if use_cpu_only and "CPUExecutionProvider" in onnxruntime.get_available_providers()
+            else None
+        )
 
-            return onnxruntime.InferenceSession(
-                str(temp_path),
-                sess_options=session_opts,
-                providers=providers
-            )
+        try:
+            model_path = importlib.resources.files("videosdk.plugins.silero.model") / "silero_vad.onnx"
+            resolved = _resource_files.enter_context(importlib.resources.as_file(model_path))
+            return onnxruntime.InferenceSession(str(resolved), sess_options=session_opts, providers=providers)
+        except Exception as e:
+            logger.warning(f"Bundled model failed: {e}, downloading...")
+
+        cached = str(_CACHE_DIR / "silero_vad.onnx")
+        if not os.path.exists(cached):
+            os.makedirs(str(_CACHE_DIR), exist_ok=True)
+            urllib.request.urlretrieve(_MODEL_DOWNLOAD_URL, cached)
+            logger.info("Silero VAD model downloaded")
+
+        return onnxruntime.InferenceSession(cached, sess_options=session_opts, providers=providers)

--- a/videosdk-plugins/videosdk-plugins-silero/videosdk/plugins/silero/onnx_runtime.py
+++ b/videosdk-plugins/videosdk-plugins-silero/videosdk/plugins/silero/onnx_runtime.py
@@ -20,7 +20,16 @@ class VadModelWrapper:
         
         self._hidden_state = np.zeros((2, 1, 128), dtype=np.float32)
         self._prev_context = np.zeros((1, self._history_len), dtype=np.float32)
-        
+
+    def reset_state(self) -> None:
+        """Reset hidden state and context to initial values.
+
+        Call when audio continuity is broken (e.g., after buffer flush)
+        to prevent the model from processing discontinuous audio.
+        """
+        self._hidden_state = np.zeros((2, 1, 128), dtype=np.float32)
+        self._prev_context = np.zeros((1, self._history_len), dtype=np.float32)
+
     @property
     def frame_size(self) -> int:
         return self._frame_size

--- a/videosdk-plugins/videosdk-plugins-silero/videosdk/plugins/silero/vad.py
+++ b/videosdk-plugins/videosdk-plugins-silero/videosdk/plugins/silero/vad.py
@@ -95,13 +95,24 @@ class SileroVAD(BaseVAD):
         return self._smoothed_prob
 
     def _flush_capture_buffer(self) -> None:
+        self._buffer_full = False  
         if self._capture_ptr <= self._pad_frames:
             return
 
         retained = self._audio_capture[self._capture_ptr - self._pad_frames : self._capture_ptr].copy()
-        self._buffer_full = False
         self._audio_capture[: self._pad_frames] = retained
         self._capture_ptr = self._pad_frames
+        self._silero.reset_state()
+        self._smoothed_prob = 0.0
+
+    async def flush(self) -> None:
+        """Reset all VAD state for clean shutdown or restart."""
+        self._raw_queue = np.array([], dtype=np.int16)
+        self._model_queue = np.array([], dtype=np.float32)
+        self._fract_offset = 0.0
+        if self._silero:
+            self._silero.reset_state()
+        self._smoothed_prob = 0.0
 
     async def process_audio(self, audio_frames: bytes, **kwargs: Any) -> None:
         try:
@@ -139,6 +150,8 @@ class SileroVAD(BaseVAD):
                 samples_needed = (frame_size * ratio) + self._fract_offset
                 consume_count = int(samples_needed)
                 self._fract_offset = samples_needed - consume_count
+                if self._fract_offset > ratio:
+                    self._fract_offset = 0.0
 
                 space_left = len(self._audio_capture) - self._capture_ptr
                 copy_amt = min(consume_count, space_left)
@@ -146,7 +159,7 @@ class SileroVAD(BaseVAD):
                 if copy_amt > 0 and len(self._raw_queue) >= consume_count:
                     self._audio_capture[self._capture_ptr : self._capture_ptr + copy_amt] = self._raw_queue[:copy_amt]
                     self._capture_ptr += copy_amt
-                elif not self._buffer_full:
+                elif copy_amt == 0 and not self._buffer_full:
                     self._buffer_full = True
                     logger.warning("VAD buffer full, dropping new samples")
 
@@ -188,8 +201,6 @@ class SileroVAD(BaseVAD):
 
                 if len(self._raw_queue) >= consume_count:
                     self._raw_queue = self._raw_queue[consume_count:]
-                else:
-                    self._raw_queue = np.array([], dtype=np.int16)
 
                 self._model_queue = self._model_queue[frame_size:]
 
@@ -211,8 +222,17 @@ class SileroVAD(BaseVAD):
                 silence_duration=self._active_silence_time,
             ),
         )
-        if self._vad_callback:
-            asyncio.create_task(self._vad_callback(evt))
+        callback = self._vad_callback  
+        if callback:
+            task = asyncio.create_task(callback(evt))
+            task.add_done_callback(self._on_dispatch_done)
+
+    def _on_dispatch_done(self, task: asyncio.Task) -> None:
+        if not task.cancelled() and task.exception():
+            logger.error(
+                f"VAD callback failed: {task.exception()}",
+                exc_info=task.exception(),
+            )
 
     async def aclose(self) -> None:
         try:


### PR DESCRIPTION
- VAD would permanently stop emitting events after several turns, freezing the entire session.
- Decouple STT and VAD via asyncio.gather so VAD never waits for STT
- Fix _buffer_full flag to always reset on flush
- Fix cleanup race condition by flushing VAD before nullifying refs
- fix: auto-download silero VAD model when bundled file is corrupted