### PR TITLE
add ObservabilityOptions to session.start() 

### DIFF
--- a/examples/observability_hooks.py
+++ b/examples/observability_hooks.py
@@ -1,5 +1,5 @@
 
-from videosdk.agents import Agent, AgentSession, Pipeline,JobContext, RoomOptions, WorkerJob
+from videosdk.agents import Agent,AgentSession, Pipeline, JobContext, RoomOptions, WorkerJob, ObservabilityOptions, RecordingOptions, LoggingOptions
 from videosdk.plugins.google import GoogleLLM
 from videosdk.plugins.deepgram import DeepgramSTT
 from videosdk.plugins.cartesia import CartesiaTTS
@@ -129,7 +129,14 @@ async def start_session(context: JobContext):
         pipeline=pipeline,
     )
 
-    await session.start(wait_for_participant=True, run_until_shutdown=True)
+    await session.start(
+        wait_for_participant=True,
+        run_until_shutdown=True,
+        observability=ObservabilityOptions(
+            recording=RecordingOptions(),                    
+            logs=LoggingOptions(level=["INFO", "DEBUG"]),  
+        ),
+    )
 
 
 def make_context() -> JobContext:
@@ -137,7 +144,6 @@ def make_context() -> JobContext:
         room_id="<room_id>",
         name="Observability Hooks",
         playground=True,
-        recording=True,
     )
 
     return JobContext(room_options=room_options)

--- a/videosdk-agents/videosdk/agents/__init__.py
+++ b/videosdk-agents/videosdk/agents/__init__.py
@@ -57,7 +57,7 @@ from .utils import (
 )
 from .room.output_stream import CustomAudioStreamTrack, TeeCustomAudioStreamTrack, TeeMixingCustomAudioStreamTrack
 from .event_emitter import EventEmitter
-from .job import WorkerJob, JobContext, RoomOptions, RecordingOptions, Options, WebSocketConfig, WebRTCConfig, TracesOptions, MetricsOptions, LoggingOptions
+from .job import WorkerJob, JobContext, RoomOptions, RecordingOptions, Options, WebSocketConfig, WebRTCConfig, TracesOptions, MetricsOptions, LoggingOptions, ObservabilityOptions
 from .worker import Worker, WorkerOptions, WorkerType
 from .utterance_handle import UtteranceHandle
 
@@ -175,6 +175,7 @@ __all__ = [
     "TracesOptions",
     "MetricsOptions",
     "LoggingOptions",
+    "ObservabilityOptions",
     "metrics_collector",
     "ImageContent",
     "segment_text",

--- a/videosdk-agents/videosdk/agents/agent_session.py
+++ b/videosdk-agents/videosdk/agents/agent_session.py
@@ -9,7 +9,7 @@ from .pipeline import Pipeline
 from .utils import get_tool_info, UserState, AgentState
 from .utterance_handle import UtteranceHandle 
 import time
-from .job import get_current_job_context
+from .job import get_current_job_context, ObservabilityOptions
 from .event_emitter import EventEmitter
 from .event_bus import global_event_emitter
 from .background_audio import BackgroundAudioHandler,BackgroundAudioHandlerConfig
@@ -189,6 +189,8 @@ class AgentSession(EventEmitter[Literal["user_state_changed", "agent_state_chang
         self,
         wait_for_participant: bool = False,
         run_until_shutdown: bool = False,
+        *,
+        observability: Optional[ObservabilityOptions] = None,
         **kwargs: Any
     ) -> None:
         """
@@ -199,25 +201,60 @@ class AgentSession(EventEmitter[Literal["user_state_changed", "agent_state_chang
         3. Start the pipeline processing
         4. Start wake-up timer if configured (but only if callback is set)
         5. Optionally handle full lifecycle management (connect, wait, shutdown)
-        
+
         Args:
             wait_for_participant: If True, wait for a participant to join before starting
             run_until_shutdown: If True, manage the full lifecycle including connection,
                                waiting for shutdown signals, and cleanup. This is a convenience
                                that internally calls ctx.run_until_shutdown() with this session.
+            observability: Grouped recording/traces/metrics/logs config. When passed, it
+                           is applied to ``ctx.room_options.observability`` before the
+                           room connects, taking precedence over any value set on
+                           ``RoomOptions``. Requires ``run_until_shutdown=True``; a
+                           warning is logged otherwise.
             **kwargs: Additional arguments to pass to the pipeline start method
-            
+
         Examples:
             Simple start (manual lifecycle management):
             ```python
             await session.start()
             ```
-            
+
             Full lifecycle management (recommended):
             ```python
             await session.start(wait_for_participant=True, run_until_shutdown=True)
             ```
+
+            Inline observability:
+            ```python
+            await session.start(
+                wait_for_participant=True,
+                run_until_shutdown=True,
+                observability=ObservabilityOptions(
+                    recording=RecordingOptions(video=True),
+                ),
+            )
+            ```
         """
+        if observability is not None:
+            ctx = None
+            try:
+                ctx = get_current_job_context()
+            except Exception as e:
+                logger.warning(f"Could not resolve JobContext for observability overrides: {e}")
+            if ctx is not None and ctx.room_options is not None:
+                if not run_until_shutdown:
+                    logger.warning(
+                        "observability= passed to session.start() but run_until_shutdown=False; "
+                        "overrides only apply if ctx.connect() has not yet run."
+                    )
+                ctx.room_options.observability = observability
+            else:
+                logger.warning(
+                    "observability= passed to session.start() but no active JobContext "
+                    "(or no RoomOptions) was found; ignoring."
+                )
+
         if run_until_shutdown:
             try:
                 ctx = get_current_job_context()

--- a/videosdk-agents/videosdk/agents/job.py
+++ b/videosdk-agents/videosdk/agents/job.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Coroutine, Optional, Any, TYPE_CHECKING, Dict
+from typing import Callable, Coroutine, Optional, Any, TYPE_CHECKING, Dict, Union
 import os
 import asyncio
 from contextvars import ContextVar
@@ -72,14 +72,70 @@ class MetricsOptions:
     export_url: Optional[str] = None
     export_headers: Optional[Dict[str, str]] = None
 
+_VALID_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR"})
+
 @dataclass
 class LoggingOptions:
-    """Configuration for log collection, level filtering, and export settings."""
+    """Configuration for log collection, level filtering, and export settings.
+
+    ``level`` accepts either:
+      * a string (threshold, e.g. ``"INFO"``) — captures that level and above
+      * a list of strings (explicit allowlist, e.g. ``["DEBUG", "ERROR"]``) —
+        captures only the listed levels
+    """
 
     enabled: bool = False
-    level: str = "INFO"
+    level: Union[str, list[str]] = "INFO"
     export_url: Optional[str] = None
     export_headers: Optional[Dict[str, str]] = None
+    send_to_dashboard: bool = False
+
+    def __post_init__(self):
+        if isinstance(self.level, str):
+            upper = self.level.upper()
+            if upper not in _VALID_LOG_LEVELS:
+                raise ValueError(
+                    f"Invalid log level {self.level!r}. Must be one of {sorted(_VALID_LOG_LEVELS)}."
+                )
+            self.level = upper
+        elif isinstance(self.level, list):
+            normalized: list[str] = []
+            for lvl in self.level:
+                if not isinstance(lvl, str):
+                    raise ValueError(
+                        f"level list entries must be strings, got {type(lvl).__name__}"
+                    )
+                upper = lvl.upper()
+                if upper not in _VALID_LOG_LEVELS:
+                    raise ValueError(
+                        f"Invalid log level {lvl!r}. Must be one of {sorted(_VALID_LOG_LEVELS)}."
+                    )
+                normalized.append(upper)
+            self.level = normalized
+        else:
+            raise ValueError(
+                f"level must be str or list[str], got {type(self.level).__name__}"
+            )
+
+
+@dataclass
+class ObservabilityOptions:
+    """Grouped config for recording, traces, metrics, and logs.
+
+    Semantics when used via this wrapper:
+      * Field absent (``None``) — framework default
+        (recording/logs OFF, traces/metrics ON via VideoSDK backend).
+      * Field present — feature ON with the supplied config, unless a
+        sub-option explicitly sets ``enabled=False``.
+
+    Usable both on :class:`RoomOptions` and inline on
+    ``AgentSession.start(observability=...)``.
+    """
+
+    recording: Optional["RecordingOptions"] = None
+    traces: Optional[TracesOptions] = None
+    metrics: Optional[MetricsOptions] = None
+    logs: Optional[LoggingOptions] = None
 
 
 @dataclass
@@ -105,13 +161,16 @@ def _coerce_recording_options_dict(ro: dict) -> RecordingOptions:
 
 
 def validate_room_options_recording(room_options: "RoomOptions") -> None:
-    """Raise ValueError if recording-related options are inconsistent."""
-    if not room_options.recording:
-        return
-    ro = room_options.recording_options
-    if isinstance(ro, dict):
-        room_options.recording_options = _coerce_recording_options_dict(ro)
-        ro = room_options.recording_options
+    """Raise ValueError if recording-related options are inconsistent.
+
+    Evaluates the resolved observability config so both the flat-field and
+    the new :class:`ObservabilityOptions` paths are checked.
+    """
+    if isinstance(room_options.recording_options, dict):
+        room_options.recording_options = _coerce_recording_options_dict(
+            room_options.recording_options
+        )
+    ro = room_options._resolved_observability().recording
     if ro is None:
         return
     if ro.screen_share and not room_options.vision:
@@ -125,7 +184,7 @@ def resolve_video_sdk_recording(
     room_options: "RoomOptions",
 ) -> tuple[Optional[bool], bool]:
     """
-    Map RoomOptions recording fields to VideoSDKHandler inputs.
+    Map the resolved observability recording config to VideoSDKHandler inputs.
 
     Returns:
         (record_audio, record_screen_share)
@@ -133,13 +192,9 @@ def resolve_video_sdk_recording(
           True → track recording, kind=audio only.
         - record_screen_share: whether to start screen_* track recording APIs.
     """
-    if not room_options.recording:
-        return None, False
-
-    ro = room_options.recording_options
+    ro = room_options._resolved_observability().recording
     if ro is None:
-        return True, False
-
+        return None, False
     if ro.video:
         return None, False
     if ro.screen_share:
@@ -180,6 +235,10 @@ class RoomOptions:
     metrics: Optional[MetricsOptions] = None
     logs: Optional[LoggingOptions] = None
 
+    # Grouped observability (recording + traces + metrics + logs).
+    # When set, takes precedence over the individual fields above at resolution time.
+    observability: Optional[ObservabilityOptions] = None
+
     # New Configuration Fields
     _transport_mode: TransportMode = field(default=TransportMode.VIDEOSDK, init=False, repr=False)
 
@@ -211,15 +270,19 @@ class RoomOptions:
         traces: Optional[TracesOptions] = None,
         metrics: Optional[MetricsOptions] = None,
         logs: Optional[LoggingOptions] = None,
+        observability: Optional[ObservabilityOptions] = None,
         **kwargs,
     ):
         # Initialize internal field
         self._transport_mode = TransportMode.VIDEOSDK
-        
+
         # Handle telemetry options
         self.traces = traces or TracesOptions()
         self.metrics = metrics or MetricsOptions()
         self.logs = logs or LoggingOptions()
+
+        # Grouped observability wrapper (optional; resolved lazily)
+        self.observability = observability
 
         # Handle connection mode
         if transport_mode:
@@ -238,6 +301,64 @@ class RoomOptions:
         for key, value in kwargs.items():
             if hasattr(self, key):
                 setattr(self, key, value)
+
+    def _resolved_observability(self) -> "ObservabilityOptions":
+        """Merge observability sources into one effective config.
+
+        Priority: ``self.observability`` > flat fields (``self.recording``,
+        ``self.traces``, …) > framework defaults
+        (recording/logs OFF, traces/metrics ON).
+        """
+        obs = self.observability
+
+        if obs is not None and obs.recording is not None:
+            recording = obs.recording
+        elif self.recording:
+            ro = self.recording_options
+            if isinstance(ro, dict):
+                ro = _coerce_recording_options_dict(ro)
+            recording = ro if isinstance(ro, RecordingOptions) else RecordingOptions()
+        else:
+            recording = None
+
+        if obs is not None and obs.traces is not None:
+            traces = obs.traces
+        else:
+            traces = self.traces or TracesOptions()
+
+        if obs is not None and obs.metrics is not None:
+            metrics = obs.metrics
+        else:
+            metrics = self.metrics or MetricsOptions()
+
+        if obs is not None and obs.logs is not None:
+            src = obs.logs
+            logs: Optional[LoggingOptions] = LoggingOptions(
+                enabled=True,
+                level=src.level,
+                export_url=src.export_url,
+                export_headers=src.export_headers,
+                send_to_dashboard=src.send_to_dashboard,
+            )
+        elif (self.logs and self.logs.enabled) or self.send_logs_to_dashboard:
+            base = self.logs or LoggingOptions()
+            level_source = base.level if (self.logs and self.logs.enabled) else self.dashboard_log_level
+            logs = LoggingOptions(
+                enabled=True,
+                level=level_source,
+                export_url=base.export_url,
+                export_headers=base.export_headers,
+                send_to_dashboard=base.send_to_dashboard or self.send_logs_to_dashboard,
+            )
+        else:
+            logs = None
+
+        return ObservabilityOptions(
+            recording=recording,
+            traces=traces,
+            metrics=metrics,
+            logs=logs,
+        )
 
 
 @dataclass
@@ -485,15 +606,16 @@ class JobContext:
                 cleanup_callback = await setup_console_voice_for_ctx(self)
                 self.add_shutdown_callback(cleanup_callback)
             else:
+                resolved_obs = self.room_options._resolved_observability()
                 self.metrics_collector.transport_mode = self.room_options.transport_mode
-                self.metrics_collector.analytics_client.configure(self.room_options.metrics)
+                self.metrics_collector.analytics_client.configure(resolved_obs.metrics)
                 if self.room_options.transport_mode == TransportMode.VIDEOSDK:
                     from .room.room import VideoSDKHandler
-                    
+
                     if not self.room_options.room_id:
                         env_room_id = (os.getenv("VIDEOSDK_ROOM_ID") or "").strip()
                         self.room_options.room_id = env_room_id or self.get_room_id()
-                    if self.room_options.send_logs_to_dashboard or (self.room_options.logs and self.room_options.logs.enabled):
+                    if resolved_obs.logs is not None:
                         from .metrics.logger_handler import LogManager, JobLogger
                         self._log_manager = LogManager()
                         self._log_manager.start(auth_token=self.videosdk_auth or "")
@@ -502,7 +624,7 @@ class JobContext:
                             room_id=self.room_options.room_id or "",
                             peer_id=self.room_options.agent_participant_id or "agent",
                             auth_token=self.videosdk_auth or "",
-                            dashboard_log_level=self.room_options.dashboard_log_level if not (self.room_options.logs and self.room_options.logs.level) else self.room_options.logs.level,
+                            dashboard_log_level=resolved_obs.logs.level,
                             send_logs_to_dashboard=True,
                         )
 
@@ -521,7 +643,7 @@ class JobContext:
                             pipeline=self._pipeline,
                             loop=self._loop,
                             vision=self.room_options.vision,
-                            recording=self.room_options.recording,
+                            recording=resolved_obs.recording is not None,
                             record_audio=record_audio_resolved,
                             record_screen_share=record_screen_share,
                             custom_camera_video_track=custom_camera_video_track,
@@ -534,9 +656,9 @@ class JobContext:
                             no_participant_timeout_seconds=self.room_options.no_participant_timeout_seconds,
                             signaling_base_url=self.room_options.signaling_base_url,
                             job_logger=self._job_logger,
-                            traces_options=self.room_options.traces,
-                            metrics_options=self.room_options.metrics,
-                            logs_options=self.room_options.logs,
+                            traces_options=resolved_obs.traces,
+                            metrics_options=resolved_obs.metrics,
+                            logs_options=resolved_obs.logs,
                             avatar_participant_id=avatar.participant_id if avatar and hasattr(avatar, 'participant_id') else None,
                         )
                     if self._pipeline and hasattr(

--- a/videosdk-agents/videosdk/agents/metrics/logger_handler.py
+++ b/videosdk-agents/videosdk/agents/metrics/logger_handler.py
@@ -4,7 +4,7 @@ import queue
 import threading
 import datetime
 from logging.handlers import QueueHandler, QueueListener
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, Union
 
 class _JobContextFilter(logging.Filter):
     """
@@ -15,14 +15,19 @@ class _JobContextFilter(logging.Filter):
     are forwarded to the queue only when the user has opted in.
     """
 
-    def __init__(self, context: Dict[str, Any]):
+    def __init__(self, context: Dict[str, Any], allowed_levels: Optional[set] = None):
         super().__init__()
         self.context = context
+        self.allowed_levels = allowed_levels  # None → threshold mode; set → allowlist
 
     def filter(self, record: logging.LogRecord) -> bool:
         for key, value in self.context.items():
             setattr(record, key, value)
-        return self.context.get("send_logs_to_dashboard", False)
+        if not self.context.get("send_logs_to_dashboard", False):
+            return False
+        if self.allowed_levels is not None and record.levelname not in self.allowed_levels:
+            return False
+        return True
 
 
 class JobLogger:
@@ -44,11 +49,11 @@ class JobLogger:
         peer_id: str,
         auth_token: str,
         session_id: Optional[str] = None,
-        dashboard_log_level: str = "INFO",
+        dashboard_log_level: Union[str, List[str]] = "INFO",
         sdk_metadata: Optional[Dict[str, Any]] = None,
         send_logs_to_dashboard: bool = False,
     ):
-        self._queue = queue 
+        self._queue = queue
         self._context: Dict[str, Any] = {
             "roomId": room_id,
             "peerId": peer_id,
@@ -66,14 +71,24 @@ class JobLogger:
 
         self._parent_logger = logging.getLogger("videosdk.agents")
 
-        target_level = getattr(logging, dashboard_log_level.upper(), logging.INFO)
+        allowed_levels: Optional[set] = None
+        if isinstance(dashboard_log_level, list):
+            allowed_levels = {lvl.upper() for lvl in dashboard_log_level}
+            level_values = [
+                getattr(logging, lvl.upper(), logging.INFO)
+                for lvl in dashboard_log_level
+            ]
+            target_level = min(level_values) if level_values else logging.INFO
+        else:
+            target_level = getattr(logging, str(dashboard_log_level).upper(), logging.INFO)
+
         if self._parent_logger.getEffectiveLevel() > target_level:
             self._parent_logger.setLevel(target_level)
 
         self._queue_handler = QueueHandler(queue)
         self._queue_handler.setLevel(target_level)
 
-        self._context_filter = _JobContextFilter(self._context)
+        self._context_filter = _JobContextFilter(self._context, allowed_levels=allowed_levels)
         self._queue_handler.addFilter(self._context_filter)
 
         self._parent_logger.addHandler(self._queue_handler)


### PR DESCRIPTION
- Observability settings (recording, traces, metrics, logs), now it can be passed at AgentSession.start via a single ObservabilityOptions allows enabling observability features directly at session startup.

**Example Usage :** 

```
from videosdk.agents import (
    AgentSession, ObservabilityOptions,
    RecordingOptions, TracesOptions, MetricsOptions, LoggingOptions,
)

session = AgentSession(agent=agent, pipeline=pipeline)

await session.start(
    wait_for_participant=True,
    run_until_shutdown=True,

    observability=ObservabilityOptions(
        recording=RecordingOptions(video=True),         
        traces=TracesOptions(export_url="https://otlp/…")
        metrics=MetricsOptions(export_url="https://…"),
        logs=LoggingOptions(level=["INFO", "DEBUG"]),  
    ),
)
```