### PR TITLE
Feat/agent transcripts interim transport

### DIFF
--- a/videosdk-agents/videosdk/agents/metrics/metrics_collector.py
+++ b/videosdk-agents/videosdk/agents/metrics/metrics_collector.py
@@ -5,7 +5,7 @@ import hashlib
 import os
 import time
 import logging
-from typing import TYPE_CHECKING, Dict, List, Optional, Any, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Any, Union
 from dataclasses import asdict
 
 from .metrics_schema import (
@@ -886,6 +886,32 @@ class MetricsCollector:
     # Transcript / response
     # ──────────────────────────────────────────────
 
+    def emit_user_transcript_transport(self, text: str, type: Literal["interim", "final"]) -> None:
+        """Broadcast user transcript for transport signaling (interim or final).
+
+        Does not update ``current_turn.user_speech`` — use only for streaming STT
+        to clients. Committed final text for metrics uses :meth:`set_user_transcript`.
+        """
+        if not text or not str(text).strip():
+            return
+        global_event_emitter.emit(
+            "USER_TRANSCRIPT_ADDED",
+            {"text": str(text).strip(), "type": type},
+        )
+
+    def emit_agent_transcript_transport(self, text: str, type: Literal["interim", "final"]) -> None:
+        """Broadcast agent transcript for transport signaling (interim or final).
+
+        Does not mutate ``current_turn.agent_speech`` — use only for streaming TTS
+        text to clients. Committed final text for metrics uses :meth:`set_agent_response`.
+        """
+        if not text or not str(text).strip():
+            return
+        global_event_emitter.emit(
+            "AGENT_TRANSCRIPT_ADDED",
+            {"text": str(text).strip(), "type": type},
+        )
+
     def set_user_transcript(self, transcript: str) -> None:
         """Set the user transcript for the current turn."""
         if self.current_turn:
@@ -908,7 +934,10 @@ class MetricsCollector:
 
             self.current_turn.user_speech = transcript
             logger.info(f"user input speech: {transcript}")
-            global_event_emitter.emit("USER_TRANSCRIPT_ADDED", {"text": transcript})
+            global_event_emitter.emit(
+                "USER_TRANSCRIPT_ADDED",
+                {"text": transcript, "type": "final"},
+            )
 
             # Update timeline
             user_events = [
@@ -922,13 +951,22 @@ class MetricsCollector:
                 if self.current_turn.timeline_event_metrics:
                     self.current_turn.timeline_event_metrics[-1].text = transcript
 
-    def set_agent_response(self, response: str) -> None:
-        """Set the agent response for the current turn."""
+    def set_agent_response(self, response: str, emit_transport: bool = True) -> None:
+        """Set the agent response for the current turn.
+
+        Args:
+            response: The agent's full response text.
+            emit_transport: When True (default), emit ``AGENT_TRANSCRIPT_ADDED`` with
+                ``type="final"`` for transport signaling. Set to False when the caller
+                will emit the final transport event later (e.g. after TTS has consumed
+                all chunks) to avoid racing with interim emits from the TTS wrapper.
+        """
         if not self.current_turn:
             self.start_turn()
         self.current_turn.agent_speech = response
         logger.info(f"agent output speech: {response}")
-        global_event_emitter.emit("AGENT_TRANSCRIPT_ADDED", {"text": response})
+        if emit_transport:
+            global_event_emitter.emit("AGENT_TRANSCRIPT_ADDED", {"text": response, "type": "final"})
 
         if not any(ev.event_type == "agent_speech" for ev in self.current_turn.timeline_event_metrics):
             current_time = time.perf_counter()

--- a/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
+++ b/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
@@ -331,7 +331,6 @@ class PipelineOrchestrator(EventEmitter[Literal[
             # Interrupt the current pipeline and start a new turn
             logger.info(f"[orchestrator] Word count {word_count} >= min_words {self.interrupt_min_words}, interrupting pipeline")
             await self._interrupt_pipeline()
-
             metrics_collector.start_turn()
             metrics_collector.set_user_transcript(text)
 
@@ -552,11 +551,17 @@ class PipelineOrchestrator(EventEmitter[Literal[
                 response_parts = []
 
                 def _safe_set_agent_response(text: str) -> None:
-                    """Only set agent response if this collector still owns the current generation."""
+                    """Only set agent response if this collector still owns the current generation.
+
+                    Emits with ``emit_transport=False`` because the TTS wrapper is still
+                    consuming queued chunks and emitting interim transport events; the
+                    final transport emit is issued by speech_generation after synthesize
+                    completes, to preserve ordering on the UI.
+                    """
                     if self.hooks and self.hooks.has_tts_stream_hook():
                         return
                     if text and self._generation_id == my_generation_id and metrics_collector.current_turn:
-                        metrics_collector.set_agent_response(text)
+                        metrics_collector.set_agent_response(text, emit_transport=False)
 
                 try:
                     async for chunk in llm_stream:
@@ -710,7 +715,7 @@ class PipelineOrchestrator(EventEmitter[Literal[
         if self.speech_generation:
             try:
                 if not (self.hooks and self.hooks.has_tts_stream_hook()):
-                    metrics_collector.set_agent_response(message)
+                    metrics_collector.set_agent_response(message, emit_transport=False)
                 await self.speech_generation.synthesize(message)
             finally:
                 handle._mark_done()
@@ -933,6 +938,14 @@ class PipelineOrchestrator(EventEmitter[Literal[
         if self._partial_response and metrics_collector.current_turn:
             if not metrics_collector.current_turn.agent_speech:
                 metrics_collector.set_agent_response(self._partial_response)
+            else:
+                # Collector already stored agent_speech with emit_transport=False; the
+                # speech_generation final emit was skipped because synthesize raised
+                # CancelledError. Emit the final transport now so the UI finalizes the
+                # last interim bubble instead of leaving it open.
+                metrics_collector.emit_agent_transcript_transport(
+                    metrics_collector.current_turn.agent_speech, type="final"
+                )
 
         if self._partial_response and self.agent:
             msg = self.agent.chat_context.add_message(

--- a/videosdk-agents/videosdk/agents/room/_transport_event_sender.py
+++ b/videosdk-agents/videosdk/agents/room/_transport_event_sender.py
@@ -53,7 +53,10 @@ class TransportEventSender:
             if hasattr(self.room_handler, "participants_data") and self.room_handler.participants_data:
                 peer_id = next(iter(self.room_handler.participants_data.keys()))
             timestamp = int(datetime.datetime.now().timestamp() * 1000)
-            asyncio.create_task(self.send_agent_transcript(text, peer_id,timestamp))
+            type = data.get("type", "final")
+            asyncio.create_task(
+                self.send_transcript_signal(text, peer_id, timestamp, type=type)
+            )
 
     def _on_agent_transcript_added(self, data: dict):
         text = data.get("text")
@@ -62,7 +65,10 @@ class TransportEventSender:
             if self.room_handler.meeting and self.room_handler.meeting.local_participant:
                 peer_id = self.room_handler.meeting.local_participant.id
             timestamp = int(datetime.datetime.now().timestamp() * 1000)
-            asyncio.create_task(self.send_agent_transcript(text, peer_id,timestamp))
+            type = data.get("type", "final")
+            asyncio.create_task(
+                self.send_transcript_signal(text, peer_id, timestamp, type=type)
+            )
 
     def _on_turn_metrics_added(self, data: dict):
         metrics = data.get("metrics")
@@ -80,14 +86,33 @@ class TransportEventSender:
                 except Exception as e:
                     logger.error(f"Error sending agent state via transport: {e}")
 
-    async def send_agent_transcript(self, text: str, peer_id: str, timestamp: int) -> None:
-        """Send agent transcript via the transport signaling channel."""
+    async def send_transcript_signal(
+        self,
+        text: str,
+        peer_id: str,
+        timestamp: int,
+        *,
+        type: str,
+    ) -> None:
+        """Send transcript over signaling (``agentTranscript``), including ``type``."""
         agent = self._get_transport_agent()
         if agent:
             try:
-                await agent.async_send_transcript(text, peer_id, timestamp)
+                logger.info(
+                    "Transport transcript: text=%r peer_id=%s timestamp=%s type=%s",
+                    text,
+                    peer_id,
+                    timestamp,
+                    type,
+                )
+                await agent.async_send_transcript(
+                    text,
+                    peer_id,
+                    str(timestamp),
+                    type=type,
+                )
             except Exception as e:
-                logger.error(f"Error sending agent transcript via transport: {e}")
+                logger.error(f"Error sending transcript via transport: {e}")
 
     async def send_agent_metrics(self, data: dict) -> None:
         """Send agent metrics via the transport signaling channel."""

--- a/videosdk-agents/videosdk/agents/speech_generation.py
+++ b/videosdk-agents/videosdk/agents/speech_generation.py
@@ -44,6 +44,22 @@ class SpeechGeneration(EventEmitter[Literal["synthesis_started", "first_audio_by
         self.tts_lock = asyncio.Lock()
         self._is_interrupted = False
         self.full_transcript = ""
+
+        if self.tts and getattr(self.tts, "supports_word_timestamps", False):
+            try:
+                self.tts.on("word_spoken", self._on_tts_word_spoken)
+            except Exception as e:
+                logger.debug(f"Failed to subscribe to TTS word_spoken: {e}")
+
+    def _on_tts_word_spoken(self, data: Any) -> None:
+        """Handler for TTS ``word_spoken`` events — emits an interim transcript."""
+        if not isinstance(data, dict):
+            return
+        cumulative = data.get("cumulative_text", "")
+        if cumulative and metrics_collector:
+            metrics_collector.emit_agent_transcript_transport(
+                cumulative, type="interim"
+            )
     
     async def start(self) -> None:
         """Start the speech generation component"""
@@ -80,7 +96,6 @@ class SpeechGeneration(EventEmitter[Literal["synthesis_started", "first_audio_by
                     nonlocal tts_start_recorded
                     logger.debug(f"[TTS DEBUG] Got text chunk: {len(text_chunk) if text_chunk else 0} chars")
                     if text_chunk and metrics_collector:
-                        # Count characters in this chunk
                         if not tts_start_recorded:
                             metrics_collector.on_tts_start()
                             tts_start_recorded = True

--- a/videosdk-agents/videosdk/agents/speech_understanding.py
+++ b/videosdk-agents/videosdk/agents/speech_understanding.py
@@ -238,6 +238,7 @@ class SpeechUnderstanding(EventEmitter[Literal["transcript_interim", "transcript
             if metrics_collector._stt_start_time is None:
                 metrics_collector.on_stt_start()
             metrics_collector.on_stt_interim_end()
+            metrics_collector.emit_user_transcript_transport(text, type="interim")
             self.emit("transcript_interim", {
                 "text": text,
                 "metadata": stt_response.metadata

--- a/videosdk-agents/videosdk/agents/tts/tts.py
+++ b/videosdk-agents/videosdk/agents/tts/tts.py
@@ -7,13 +7,14 @@ import logging
 import asyncio
 logger = logging.getLogger(__name__)
 
-class TTS(EventEmitter[Literal["error"]]):
+class TTS(EventEmitter[Literal["error", "word_spoken"]]):
     """Base class for Text-to-Speech implementations"""
     
     def __init__(
         self,
         sample_rate: int = 16000,
-        num_channels: int = 1
+        num_channels: int = 1,
+        word_timestamps: bool = False,
     ) -> None:
         super().__init__()
         self._label = f"{type(self).__module__}.{type(self).__name__}"
@@ -21,6 +22,7 @@ class TTS(EventEmitter[Literal["error"]]):
         self._num_channels = num_channels
         self._first_audio_callback: Optional[Callable[[], Awaitable[None]]] = None
         self.audio_track = None 
+        self.supports_word_timestamps = word_timestamps
 
     @property
     def label(self) -> str:

--- a/videosdk-plugins/videosdk-plugins-cartesia/videosdk/plugins/cartesia/tts.py
+++ b/videosdk-plugins/videosdk-plugins-cartesia/videosdk/plugins/cartesia/tts.py
@@ -33,8 +33,9 @@ class CartesiaTTS(TTS):
         language: str = "en",
         base_url: str = "https://api.cartesia.ai",
         generation_config: GenerationConfig = GenerationConfig(),
-        pronunciation_dict_id:str|None = None,
-        max_buffer_delay_ms:int|None = None
+        pronunciation_dict_id: str | None = None,
+        max_buffer_delay_ms: int | None = None,
+        word_timestamps: bool = False,
     ) -> None:
         """Initialize the Cartesia TTS plugin
         Args:
@@ -48,7 +49,11 @@ class CartesiaTTS(TTS):
             pronunciation_dict_id (str): The pronunciation dictionary id to use for custom pronunciations.
             max_buffer_delay_ms(int): for max_buffer_delay_ms before streaming.
         """
-        super().__init__(sample_rate=CARTESIA_SAMPLE_RATE, num_channels=CARTESIA_CHANNELS)
+        super().__init__(
+            sample_rate=CARTESIA_SAMPLE_RATE,
+            num_channels=CARTESIA_CHANNELS,
+            word_timestamps=word_timestamps,
+        )
 
         self.model = model
         self.language = language
@@ -72,9 +77,22 @@ class CartesiaTTS(TTS):
         self._receive_task: asyncio.Task | None = None
         self._context_futures: dict[str, asyncio.Future[None]] = {}
 
+        # Word-timestamp-driven transcript sync
+        self._audio_start_time: Optional[float] = None
+        self._spoken_words: List[str] = []
+        self._word_schedule_tasks: List[asyncio.Task] = []
+        self._last_scheduled_start_sec: float = -1.0
+
     def reset_first_audio_tracking(self) -> None:
         """Reset the first audio tracking state for the next TTS task"""
         self._first_chunk_sent = False
+        self._audio_start_time = None
+        self._spoken_words = []
+        for task in self._word_schedule_tasks:
+            if not task.done():
+                task.cancel()
+        self._word_schedule_tasks = []
+        self._last_scheduled_start_sec = -1.0
 
     async def synthesize(
         self, text: AsyncIterator[str] | str, voice_id: Optional[Union[str, List[float]]] = None, **kwargs: Any,
@@ -131,7 +149,8 @@ class CartesiaTTS(TTS):
                 "model_id": self.model, "language": self.language,
                 "voice": voice_payload,
                 "output_format": {"container": "raw", "encoding": "pcm_s16le", "sample_rate": self.sample_rate},
-                "add_timestamps": True, "context_id": context_id,
+                "add_timestamps": self.supports_word_timestamps,
+                "context_id": context_id,
                 "generation_config": asdict(self._generation_config),
                 "pronunciation_dictionary_id":self.pronunciation_dictionary_id,
                 "max_buffer_delay_ms":self.max_buffer_delay_ms
@@ -174,6 +193,19 @@ class CartesiaTTS(TTS):
 
                 if data.get("type") == "error":
                     future.set_exception(RuntimeError(f"Cartesia API error: {json.dumps(data)}"))
+                elif data.get("type") == "timestamps" and "word_timestamps" in data:
+                    wt = data["word_timestamps"] or {}
+                    words = wt.get("words", []) or []
+                    starts = wt.get("start", []) or []
+                    for word, start_sec in zip(words, starts):
+                        start_sec_f = float(start_sec)
+                        if start_sec_f <= self._last_scheduled_start_sec:
+                            continue
+                        self._last_scheduled_start_sec = start_sec_f
+                        task = asyncio.create_task(
+                            self._schedule_word_emit(word, start_sec_f)
+                        )
+                        self._word_schedule_tasks.append(task)
                 elif "data" in data and data["data"]:
                     await self._stream_audio(base64.b64decode(data["data"]))
                 elif data.get("done"):
@@ -210,16 +242,47 @@ class CartesiaTTS(TTS):
         """Streams a chunk of audio to the audio track."""
         if self._interrupted or not audio_chunk: return
 
-        if not self._first_chunk_sent and self._first_audio_callback:
+        if not self._first_chunk_sent:
             self._first_chunk_sent = True
-            await self._first_audio_callback()
+            self._audio_start_time = asyncio.get_event_loop().time()
+            if self._first_audio_callback:
+                await self._first_audio_callback()
 
         if self.audio_track:
             await self.audio_track.add_new_bytes(audio_chunk)
 
+    async def _schedule_word_emit(self, word: str, start_sec: float) -> None:
+        """Emit a ``word_spoken`` event at the moment its audio begins to play."""
+        while self._audio_start_time is None and not self._interrupted:
+            await asyncio.sleep(0.01)
+        if self._interrupted or self._audio_start_time is None:
+            return
+
+        target_time = self._audio_start_time + float(start_sec)
+        now = asyncio.get_event_loop().time()
+        delay = target_time - now
+        if delay > 0:
+            try:
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                return
+        if self._interrupted:
+            return
+
+        self._spoken_words.append(word)
+        cumulative = " ".join(self._spoken_words)
+        try:
+            self.emit("word_spoken", {"word": word, "cumulative_text": cumulative})
+        except Exception:
+            pass
+
     async def interrupt(self) -> None:
         """Interrupts any ongoing TTS, stopping audio playback and network activity."""
         self._interrupted = True
+        for task in self._word_schedule_tasks:
+            if not task.done():
+                task.cancel()
+        self._word_schedule_tasks = []
         if self.audio_track: self.audio_track.interrupt()
         if self._ws_connection and not self._ws_connection.closed:
             await self._ws_connection.close()

--- a/videosdk-plugins/videosdk-plugins-elevenlabs/videosdk/plugins/elevenlabs/tts.py
+++ b/videosdk-plugins/videosdk-plugins-elevenlabs/videosdk/plugins/elevenlabs/tts.py
@@ -43,9 +43,10 @@ class ElevenLabsTTS(TTS):
         enable_streaming: bool = True,
         inactivity_timeout: int = WS_INACTIVITY_TIMEOUT,
         language: str = "en",
-        enable_ssml_parsing:bool=False,
-        apply_text_normalization:Literal["auto","on","off"]="auto",
-        auto_mode:bool=False
+        enable_ssml_parsing: bool = False,
+        apply_text_normalization: Literal["auto", "on", "off"] = "auto",
+        auto_mode: bool = False,
+        word_timestamps: bool = False,
     ) -> None:
         """Initialize the ElevenLabs TTS plugin.
 
@@ -68,7 +69,9 @@ class ElevenLabsTTS(TTS):
             auto_mode (bool): Reduces latency by disabling chunk schedule and buffers. Recommended for full sentences/phrases.
         """
         super().__init__(
-            sample_rate=ELEVENLABS_SAMPLE_RATE, num_channels=ELEVENLABS_CHANNELS
+            sample_rate=ELEVENLABS_SAMPLE_RATE,
+            num_channels=ELEVENLABS_CHANNELS,
+            word_timestamps=word_timestamps,
         )
 
         self.model = model
@@ -109,9 +112,25 @@ class ElevenLabsTTS(TTS):
         self._active_contexts: set[str] = set()
         self._context_futures: dict[str, asyncio.Future[None]] = {}
 
+        self._audio_start_time: Optional[float] = None
+        self._spoken_words: list[str] = []
+        self._word_schedule_tasks: list[asyncio.Task] = []
+        self._last_scheduled_start_sec: float = -1.0
+        self._pending_word_chars: list[str] = []
+        self._pending_word_start_sec: Optional[float] = None
+
     def reset_first_audio_tracking(self) -> None:
         """Reset the first audio tracking state for next TTS task"""
         self._first_chunk_sent = False
+        self._audio_start_time = None
+        self._spoken_words = []
+        for task in self._word_schedule_tasks:
+            if not task.done():
+                task.cancel()
+        self._word_schedule_tasks = []
+        self._last_scheduled_start_sec = -1.0
+        self._pending_word_chars = []
+        self._pending_word_start_sec = None
 
     async def synthesize(
         self,
@@ -254,16 +273,91 @@ class ElevenLabsTTS(TTS):
         if not audio_bytes or self._should_stop:
             return
 
-        if not self._first_chunk_sent and hasattr(self, '_first_audio_callback') and self._first_audio_callback:
+        if not self._first_chunk_sent:
             self._first_chunk_sent = True
-            asyncio.create_task(self._first_audio_callback())
+            self._audio_start_time = asyncio.get_event_loop().time()
+            if hasattr(self, '_first_audio_callback') and self._first_audio_callback:
+                asyncio.create_task(self._first_audio_callback())
 
         if self.audio_track and self.loop:
             await self.audio_track.add_new_bytes(audio_bytes)
 
+    async def _schedule_word_emit(self, word: str, start_sec: float) -> None:
+        """Emit a ``word_spoken`` event at the moment its audio begins to play."""
+        while self._audio_start_time is None and not self._should_stop:
+            await asyncio.sleep(0.01)
+        if self._should_stop or self._audio_start_time is None:
+            return
+
+        target_time = self._audio_start_time + float(start_sec)
+        now = asyncio.get_event_loop().time()
+        delay = target_time - now
+        if delay > 0:
+            try:
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                return
+        if self._should_stop:
+            return
+
+        self._spoken_words.append(word)
+        cumulative = " ".join(self._spoken_words)
+        try:
+            self.emit("word_spoken", {"word": word, "cumulative_text": cumulative})
+        except Exception:
+            pass
+
+    def _schedule_words_from_alignment(self, alignment: dict) -> None:
+        """Parse an ElevenLabs alignment payload and schedule per-word emits.
+
+        ElevenLabs returns character-level alignment (``chars`` /
+        ``charStartTimesMs``). We aggregate consecutive non-whitespace chars
+        into whole words, then schedule each word at its first-char start time
+        so the UI renders word-by-word synced with audio playback.
+        """
+        if not alignment:
+            return
+        chars = alignment.get("chars") or alignment.get("characters") or []
+        if "charStartTimesMs" in alignment:
+            starts_sec = [float(t) / 1000.0 for t in alignment["charStartTimesMs"]]
+        elif "character_start_times_seconds" in alignment:
+            starts_sec = [float(t) for t in alignment["character_start_times_seconds"]]
+        else:
+            return
+
+        for ch, start_sec in zip(chars, starts_sec):
+            if ch.isspace():
+                self._flush_pending_word()
+            else:
+                if not self._pending_word_chars:
+                    self._pending_word_start_sec = start_sec
+                self._pending_word_chars.append(ch)
+
+    def _flush_pending_word(self) -> None:
+        """Schedule emission of any word currently being accumulated."""
+        if not self._pending_word_chars or self._pending_word_start_sec is None:
+            self._pending_word_chars = []
+            self._pending_word_start_sec = None
+            return
+        word = "".join(self._pending_word_chars)
+        start_sec = self._pending_word_start_sec
+        self._pending_word_chars = []
+        self._pending_word_start_sec = None
+        if start_sec <= self._last_scheduled_start_sec:
+            return
+        self._last_scheduled_start_sec = start_sec
+        self._word_schedule_tasks.append(
+            asyncio.create_task(self._schedule_word_emit(word, start_sec))
+        )
+
     async def interrupt(self) -> None:
         """Simple but effective interruption"""
         self._should_stop = True
+
+        for task in self._word_schedule_tasks:
+            if not task.done():
+                task.cancel()
+        self._word_schedule_tasks = []
 
         if self.audio_track:
             self.audio_track.interrupt()
@@ -395,13 +489,21 @@ class ElevenLabsTTS(TTS):
                     if data.get("audio"):
                         audio_chunk = base64.b64decode(data["audio"]) if isinstance(data["audio"], str) else None
                         if audio_chunk:
-                            if not self._first_chunk_sent and hasattr(self, '_first_audio_callback') and self._first_audio_callback:
+                            if not self._first_chunk_sent:
                                 self._first_chunk_sent = True
-                                asyncio.create_task(self._first_audio_callback())
+                                self._audio_start_time = asyncio.get_event_loop().time()
+                                if hasattr(self, '_first_audio_callback') and self._first_audio_callback:
+                                    asyncio.create_task(self._first_audio_callback())
                             if self.audio_track:
                                 await self.audio_track.add_new_bytes(audio_chunk)
+                    if self.supports_word_timestamps:
+                        alignment = data.get("alignment") or data.get("normalizedAlignment")
+                        if alignment:
+                            self._schedule_words_from_alignment(alignment)
 
                     if data.get("is_final") or data.get("isFinal"):
+                        if self.supports_word_timestamps:
+                            self._flush_pending_word()
                         ctx_id = data.get("contextId")
                         if ctx_id:
                             fut = self._context_futures.pop(ctx_id, None)


### PR DESCRIPTION
feat : support interim transcripts over transport

  - extend existing transcript streaming to support interim agent results
  - emit transcripts with word-level timestamps
  - send interim and final transcript events via transport to client SDK
  - ensure synchronization between transcript generation and transport delivery
  - agent transcript renders word-by-word synced to audio
  - Supported providers: Cartesia, ElevenLabs.

Example Usage : 
- Opt in per TTS plugin via the word_timestamps constructor flag. Default is False.

   **_- Cartesia_** 
         ` tts = CartesiaTTS(word_timestamps=True)`
          
  **_- ElevenLabs_** 
          `tts = ElevenLabsTTS(word_timestamps=True)`