### PR TITLE
fix: send transcript events only when required using additional checks

### DIFF
--- a/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
+++ b/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
@@ -552,16 +552,13 @@ class PipelineOrchestrator(EventEmitter[Literal[
 
                 def _safe_set_agent_response(text: str) -> None:
                     """Only set agent response if this collector still owns the current generation.
-
-                    Emits with ``emit_transport=False`` because the TTS wrapper is still
-                    consuming queued chunks and emitting interim transport events; the
-                    final transport emit is issued by speech_generation after synthesize
-                    completes, to preserve ordering on the UI.
                     """
                     if self.hooks and self.hooks.has_tts_stream_hook():
                         return
                     if text and self._generation_id == my_generation_id and metrics_collector.current_turn:
-                        metrics_collector.set_agent_response(text, emit_transport=False)
+                        tts = self.speech_generation.tts if self.speech_generation else None
+                        emit = not bool(getattr(tts, "supports_word_timestamps", False))
+                        metrics_collector.set_agent_response(text, emit_transport=emit)
 
                 try:
                     async for chunk in llm_stream:
@@ -715,7 +712,9 @@ class PipelineOrchestrator(EventEmitter[Literal[
         if self.speech_generation:
             try:
                 if not (self.hooks and self.hooks.has_tts_stream_hook()):
-                    metrics_collector.set_agent_response(message, emit_transport=False)
+                    tts = self.speech_generation.tts
+                    emit = not bool(getattr(tts, "supports_word_timestamps", False))
+                    metrics_collector.set_agent_response(message, emit_transport=emit)
                 await self.speech_generation.synthesize(message)
             finally:
                 handle._mark_done()
@@ -939,10 +938,6 @@ class PipelineOrchestrator(EventEmitter[Literal[
             if not metrics_collector.current_turn.agent_speech:
                 metrics_collector.set_agent_response(self._partial_response)
             else:
-                # Collector already stored agent_speech with emit_transport=False; the
-                # speech_generation final emit was skipped because synthesize raised
-                # CancelledError. Emit the final transport now so the UI finalizes the
-                # last interim bubble instead of leaving it open.
                 metrics_collector.emit_agent_transcript_transport(
                     metrics_collector.current_turn.agent_speech, type="final"
                 )

--- a/videosdk-agents/videosdk/agents/speech_generation.py
+++ b/videosdk-agents/videosdk/agents/speech_generation.py
@@ -50,6 +50,7 @@ class SpeechGeneration(EventEmitter[Literal["synthesis_started", "first_audio_by
                 self.tts.on("word_spoken", self._on_tts_word_spoken)
             except Exception as e:
                 logger.debug(f"Failed to subscribe to TTS word_spoken: {e}")
+            self.on("last_audio_byte", self._on_final_agent_transcript)
 
     def _on_tts_word_spoken(self, data: Any) -> None:
         """Handler for TTS ``word_spoken`` events — emits an interim transcript."""
@@ -59,6 +60,14 @@ class SpeechGeneration(EventEmitter[Literal["synthesis_started", "first_audio_by
         if cumulative and metrics_collector:
             metrics_collector.emit_agent_transcript_transport(
                 cumulative, type="interim"
+            )
+
+    def _on_final_agent_transcript(self, data: Any) -> None:
+        """Emit the final agent transcript after playback completes.
+        """
+        if self.full_transcript and metrics_collector:
+            metrics_collector.emit_agent_transcript_transport(
+                self.full_transcript, type="final"
             )
     
     async def start(self) -> None:
@@ -146,7 +155,8 @@ class SpeechGeneration(EventEmitter[Literal["synthesis_started", "first_audio_by
                             await self.audio_track.add_new_bytes(audio_chunk)
 
                     if self.full_transcript and metrics_collector.current_turn:
-                        metrics_collector.set_agent_response(self.full_transcript)
+                        emit = not getattr(self.tts, "supports_word_timestamps", False)
+                        metrics_collector.set_agent_response(self.full_transcript, emit_transport=emit)
                     metrics_collector.on_agent_speech_end()
                     metrics_collector.complete_turn()
 
@@ -212,8 +222,6 @@ class SpeechGeneration(EventEmitter[Literal["synthesis_started", "first_audio_by
 
             async def on_last_audio_byte():
                 """Called when synthesis is complete"""
-                if self.full_transcript and metrics_collector.current_turn:
-                    pass
                 metrics_collector.on_agent_speech_end()
                 metrics_collector.complete_turn()
 

--- a/videosdk-agents/videosdk/agents/speech_understanding.py
+++ b/videosdk-agents/videosdk/agents/speech_understanding.py
@@ -238,7 +238,8 @@ class SpeechUnderstanding(EventEmitter[Literal["transcript_interim", "transcript
             if metrics_collector._stt_start_time is None:
                 metrics_collector.on_stt_start()
             metrics_collector.on_stt_interim_end()
-            metrics_collector.emit_user_transcript_transport(text, type="interim")
+            if getattr(self.stt, "forward_interim_transcripts", False):
+                metrics_collector.emit_user_transcript_transport(text, type="interim")
             self.emit("transcript_interim", {
                 "text": text,
                 "metadata": stt_response.metadata

--- a/videosdk-agents/videosdk/agents/stt/stt.py
+++ b/videosdk-agents/videosdk/agents/stt/stt.py
@@ -52,13 +52,15 @@ class STTResponse(BaseModel):
 
 class STT(EventEmitter[Literal["error"]]):
     """Base class for Speech-to-Text implementations"""
-    
+
     def __init__(
         self,
+        forward_interim_transcripts: bool = False,
     ) -> None:
         super().__init__()
         self._label = f"{type(self).__module__}.{type(self).__name__}"
         self._transcript_callback: Optional[Callable[[STTResponse], Awaitable[None]]] = None
+        self.forward_interim_transcripts = forward_interim_transcripts
         
     @property
     def label(self) -> str:


### PR DESCRIPTION
- To receive interim transcription results from the user via transport events, you need to set 
`stt = DeepgramSTT()` and enable `stt.forward_interim_transcripts = True`.