### PR TITLE
Add Metrics of eou wait ms

### DIFF
--- a/videosdk-agents/videosdk/agents/metrics/metrics_collector.py
+++ b/videosdk-agents/videosdk/agents/metrics/metrics_collector.py
@@ -669,15 +669,26 @@ class MetricsCollector:
             self._eou_start_time = None
     
     def on_wait_for_additional_speech(self, duration: float, eou_probability: float):
-        if self.current_turn:
-            if not self.current_turn.eou_metrics:
-                self.current_turn.eou_metrics.append(EouMetrics())
-            eou = self.current_turn.eou_metrics[-1]
-            eou.wait_for_additional_speech_duration = duration
-            eou.eou_probability = eou_probability
-            eou.waited_for_additional_speech = True
-            logger.info(f"wait for additional speech duration: {duration}ms")
-            logger.info(f"wait for additional speech eou probability: {eou_probability}")
+        if not self.current_turn or not self.current_turn.eou_metrics:
+            return
+        eou = self.current_turn.eou_metrics[-1]
+        eou.eou_wait_ms = self._round_latency(duration)
+        eou.eou_probability = eou_probability
+        eou.waited_for_additional_speech = True
+        logger.info(f"eou wait scheduled: {eou.eou_wait_ms}ms")
+        logger.info(f"eou wait eou probability: {eou_probability}")
+
+    def on_wait_for_additional_speech_complete(self, actual_duration: float) -> None:
+        """Overwrite the scheduled wait duration with the actual elapsed wait.
+
+        Called when the wait timer fires naturally or is cancelled by continued speech.
+        The actual elapsed value is what gets summed into E2E latency.
+        """
+        if not self.current_turn or not self.current_turn.eou_metrics:
+            return
+        eou = self.current_turn.eou_metrics[-1]
+        eou.eou_wait_ms = self._round_latency(actual_duration)
+        logger.info(f"eou wait actual: {eou.eou_wait_ms}ms")
 
     # ──────────────────────────────────────────────
     # LLM metrics
@@ -1275,6 +1286,8 @@ class MetricsCollector:
             data["eou_latency"] = eou.eou_latency
             data["eou_start_time"] = eou.eou_start_time
             data["eou_end_time"] = eou.eou_end_time
+            data["eou_wait_ms"] = eou.eou_wait_ms
+            data["eou_probability"] = eou.eou_probability
 
         # Flatten the last LLM metrics entry
         if turn.llm_metrics:
@@ -1405,6 +1418,8 @@ class MetricsCollector:
             "eou_latency": "eouLatency",
             "eou_start_time": "eouStartTime",
             "eou_end_time": "eouEndTime",
+            "eou_wait_ms": "eouWaitMs",
+            "eou_probability": "eouProbability",
 
             # Realtime (full s2s) metrics
             "realtime_ttfb": "realtimeTtfb",

--- a/videosdk-agents/videosdk/agents/metrics/metrics_schema.py
+++ b/videosdk-agents/videosdk/agents/metrics/metrics_schema.py
@@ -89,7 +89,7 @@ class EouMetrics(BaseComponentMetrics):
     max_speech_wait_timeout: Optional[float] = None
     eou_avg_delay: Optional[float] = None
     waited_for_additional_speech: bool = False
-    wait_for_additional_speech_duration: Optional[float] = None
+    eou_wait_ms: Optional[float] = None
 
 
 @dataclass
@@ -286,6 +286,8 @@ class TurnMetrics:
             eou = self.eou_metrics[-1]
             if eou.eou_latency is not None:
                 e2e_components.append(eou.eou_latency)
+            if eou.eou_wait_ms is not None:
+                e2e_components.append(eou.eou_wait_ms)
 
         if self.llm_metrics:
             llm = self.llm_metrics[-1]

--- a/videosdk-agents/videosdk/agents/metrics/traces_flow.py
+++ b/videosdk-agents/videosdk/agents/metrics/traces_flow.py
@@ -475,18 +475,19 @@ class TracesFlowManager:
                     parent_span=turn_span,
                     start_time=eou.eou_start_time if eou else None,
                 )
-                if eou.waited_for_additional_speech:
-                    delay = round(eou.wait_for_additional_speech_duration, 4)
+                if eou.waited_for_additional_speech and eou.eou_wait_ms is not None and eou.eou_end_time is not None:
+                    delay_ms = round(eou.eou_wait_ms, 4)
+                    delay_sec = delay_ms / 1000.0
                     with trace.use_span(eou_span):
-                        wait_for_additional_speech_span =create_span (
-                            "Wait for Additional Speech",
+                        eou_wait_span = create_span(
+                            "EOU Wait",
                             {
-                                "wait_for_additional_speech_duration":delay,
-                                "eou_probability": round(eou.eou_probability, 4),
+                                "eou_wait_ms": delay_ms,
+                                "eou_probability": round(eou.eou_probability or 0, 4),
                             },
                             start_time=eou.eou_end_time,
                         )
-                        self.end_span(wait_for_additional_speech_span, status_code=StatusCode.OK, end_time=eou.eou_end_time + delay)
+                        self.end_span(eou_wait_span, status_code=StatusCode.OK, end_time=eou.eou_end_time + delay_sec)
                 
                 if eou_span:
                     for error in eou_errors:

--- a/videosdk-agents/videosdk/agents/speech_understanding.py
+++ b/videosdk-agents/videosdk/agents/speech_understanding.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Callable, Awaitable, Literal, TYPE_CHECKING
 import asyncio
 import logging
+import time
 from .event_emitter import EventEmitter
 from .stt.stt import STT, STTResponse, SpeechEventType
 from .vad import VAD, VADResponse, VADEventType
@@ -63,6 +64,7 @@ class SpeechUnderstanding(EventEmitter[Literal["transcript_interim", "transcript
         self._accumulated_transcript = ""
         self._waiting_for_more_speech = False
         self._wait_timer: asyncio.TimerHandle | None = None
+        self._wait_started_at: float | None = None
         self._transcript_processing_lock = asyncio.Lock()
         self._is_user_speaking = False
         self._stt_started = False
@@ -296,24 +298,38 @@ class SpeechUnderstanding(EventEmitter[Literal["transcript_interim", "transcript
         if self._waiting_for_more_speech:
             if self._wait_timer:
                 self._wait_timer.cancel()
-        
+            self._record_wait_elapsed()
+
         self._waiting_for_more_speech = True
-        
+        self._wait_started_at = time.perf_counter()
+
         loop = asyncio.get_event_loop()
         self._wait_timer = loop.call_later(
             delay,
             lambda: asyncio.create_task(self._on_speech_timeout())
         )
+
+    def _record_wait_elapsed(self) -> None:
+        """Report the actual elapsed wait time to metrics, then clear the start marker."""
+        if self._wait_started_at is None:
+            return
+        elapsed = time.perf_counter() - self._wait_started_at
+        self._wait_started_at = None
+        try:
+            metrics_collector.on_wait_for_additional_speech_complete(elapsed)
+        except Exception as e:
+            logger.error(f"Failed to record actual wait duration: {e}")
     
     async def _on_speech_timeout(self) -> None:
         """Handle timeout when no additional speech is detected"""
         async with self._transcript_processing_lock:
             if not self._waiting_for_more_speech:
                 return
-            
+
             self._waiting_for_more_speech = False
             self._wait_timer = None
-            
+            self._record_wait_elapsed()
+
             await self._finalize_transcript()
     
     async def _finalize_transcript(self) -> None:
@@ -341,7 +357,8 @@ class SpeechUnderstanding(EventEmitter[Literal["transcript_interim", "transcript
         if self._wait_timer:
             self._wait_timer.cancel()
             self._wait_timer = None
-        
+
+        self._record_wait_elapsed()
         self._waiting_for_more_speech = False
     
     async def _handle_turn_resumed(self, resumed_text: str) -> None:
@@ -392,9 +409,10 @@ class SpeechUnderstanding(EventEmitter[Literal["transcript_interim", "transcript
         if self._wait_timer:
             self._wait_timer.cancel()
             self._wait_timer = None
-        
+
         self._accumulated_transcript = ""
         self._waiting_for_more_speech = False
+        self._wait_started_at = None
         self._preemptive_transcript = None
 
         if self.vad:

--- a/videosdk-plugins/videosdk-plugins-silero/videosdk/plugins/silero/model/.gitattributes
+++ b/videosdk-plugins/videosdk-plugins-silero/videosdk/plugins/silero/model/.gitattributes
@@ -1,0 +1,1 @@
+*.onnx filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
- Surfaces the EOU "wait for additional speech" debounce as a first-class latency metric (eou_wait_ms) and folds it into `e2e_latency`.
- Also Added in Trace Span
- chore: track .onnx via LFS in .gitattributes