### PR TITLE
fix(lifecycle): release worker job slot on manual agent.hangup()

### DIFF
--- a/examples/agent_hangup.py
+++ b/examples/agent_hangup.py
@@ -1,0 +1,73 @@
+import asyncio
+from videosdk.agents import Agent, AgentSession, Pipeline, WorkerJob, JobContext, RoomOptions, Options, function_tool
+from videosdk.plugins.deepgram import DeepgramSTT
+from videosdk.plugins.google import GoogleLLM
+from videosdk.plugins.silero import SileroVAD
+from videosdk.plugins.cartesia import CartesiaTTS 
+from videosdk.plugins.turn_detector import TurnDetector, pre_download_model
+
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", handlers=[logging.StreamHandler()])
+
+from dotenv import load_dotenv
+load_dotenv(override=True)
+
+pre_download_model()
+
+class VoiceAgent(Agent):
+    def __init__(self):
+        super().__init__(
+            instructions=(
+                "You are a helpful voice assistant that can answer questions. "
+                "When the user asks to hang up, end the call, or stop the conversation, "
+                "call the end_call function tool."
+            )
+        )
+    async def on_enter(self) -> None:
+        await self.session.say("Hello, how can I help you today?")
+
+    async def on_exit(self) -> None:
+        await self.session.say("Goodbye!")
+
+    @function_tool
+    async def end_call(self) -> dict:
+        """End the call when the user asks to hang up, end the conversation, or says goodbye."""
+        asyncio.create_task(self._announce_and_hangup())
+        return {"status": "ending_call"}
+
+    async def _announce_and_hangup(self) -> None:
+        if not self.session:
+            return
+        self.session.interrupt()
+        await asyncio.sleep(1)
+        handle = await self.session.say("I am ending the call now.", interruptible=False)
+        await handle
+        await asyncio.sleep(1)
+        await self.hangup()
+
+async def entrypoint(ctx: JobContext):
+
+    agent = VoiceAgent()
+
+    pipeline=Pipeline(
+        stt=DeepgramSTT(),
+        llm=GoogleLLM(),
+        tts=CartesiaTTS(),
+        vad=SileroVAD(),
+        turn_detector=TurnDetector()
+    )
+    
+    session = AgentSession(
+        agent=agent,
+        pipeline=pipeline
+    )
+
+    await session.start(wait_for_participant=True, run_until_shutdown=True)
+
+def make_context() -> JobContext:
+    room_options = RoomOptions(name="Agent Hangup Example", playground=True)
+    return JobContext(room_options=room_options) 
+ 
+if __name__ == "__main__":
+    job = WorkerJob(entrypoint=entrypoint, jobctx=make_context, options=Options(agent_id="YOUR_AGENT_ID", max_processes=2, register=True, host="localhost", port=8081))
+    job.start()

--- a/videosdk-agents/videosdk/agents/agent.py
+++ b/videosdk-agents/videosdk/agents/agent.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Literal, Optional
+import asyncio
 import inspect
 from .event_emitter import EventEmitter
 from .llm.chat_context import ChatContext
@@ -110,7 +111,7 @@ class Agent(EventEmitter[Literal["agent_started"]], ABC):
     
     async def hangup(self) -> None:
         """Hang up the agent"""
-        await self.session.hangup("manual_hangup")
+        asyncio.create_task(self.session.hangup("manual_hangup"))
     
     def set_thinking_audio(self, file: str = None, volume: float = 0.3):
         """Set the thinking background for the agent"""

--- a/videosdk-agents/videosdk/agents/job.py
+++ b/videosdk-agents/videosdk/agents/job.py
@@ -759,7 +759,10 @@ class JobContext:
         logger.info("JobContext shutting down")
         for callback in self._shutdown_callbacks:
             try:
-                await callback()
+                await asyncio.wait_for(callback(), timeout=15.0)
+            except asyncio.TimeoutError:
+                cb_name = getattr(callback, "__name__", repr(callback))
+                logger.warning(f"Shutdown callback {cb_name} timed out")
             except Exception as e:
                 logger.error(f"Error in shutdown callback: {e}")
 
@@ -879,7 +882,9 @@ class JobContext:
             async def cleanup_session():
                 logger.info("Cleaning up session...")
                 try:
-                    await session.close()
+                    await asyncio.wait_for(session.close(), timeout=15.0)
+                except asyncio.TimeoutError:
+                    logger.warning("session.close() timed out during shutdown")
                 except Exception as e:
                     logger.error(f"Error closing session in cleanup: {e}")
                 shutdown_event.set()

--- a/videosdk-agents/videosdk/agents/room/room.py
+++ b/videosdk-agents/videosdk/agents/room/room.py
@@ -466,8 +466,9 @@ class VideoSDKHandler(BaseTransportHandler):
                 self.on_session_end(reason)
             except Exception as e:
                 logger.error(f"Error in session end callback: {e}")
+        else:
+            await self.leave()
 
-        await self.leave()
         self._session_ended = True
 
         if not self._first_participant_event.is_set():


### PR DESCRIPTION
- Calling agent.hangup() from a function tool or LLM hook never decremented the worker's job count because the entrypoint subprocess could not exit.