### PR TITLE
feat : llm and turn hooks in realtime mode

### DIFF
--- a/examples/realtime_pipeline_hooks.py
+++ b/examples/realtime_pipeline_hooks.py
@@ -1,0 +1,88 @@
+from videosdk.agents import Agent, AgentSession, Pipeline, JobContext, RoomOptions, WorkerJob
+from videosdk.plugins.google import GeminiRealtime, GeminiLiveConfig
+import asyncio
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", handlers=[logging.StreamHandler()])
+
+FAREWELL_PHRASES = ("goodbye", "bye!", "have a nice day", "have a good day", "talk to you later")
+
+class MyVoiceAgent(Agent):
+    def __init__(self):
+        super().__init__(
+            instructions=(
+                "You are a helpful voice assistant that can answer questions. "
+                "When the user asks to hang up, end the call, or stop the conversation, "
+            )
+        )
+
+    async def on_enter(self) -> None:
+        await self.session.say("Hello, how can I help you today?")
+    
+    async def on_exit(self) -> None:
+        await self.session.say("Goodbye!")
+
+async def start_session(context: JobContext):
+    agent = MyVoiceAgent()
+    model = GeminiRealtime(
+        model="gemini-3.1-flash-live-preview",
+        # When GOOGLE_API_KEY is set in .env - DON'T pass api_key parameter
+        # api_key="AIXXXXXXXXXXXXXXXXXXXX", 
+        config=GeminiLiveConfig(
+            voice="Leda", # Puck, Charon, Kore, Fenrir, Aoede, Leda, Orus, and Zephyr.
+            response_modalities=["AUDIO"]
+        )
+    )
+    
+    pipeline = Pipeline(llm=model)
+    session = AgentSession(
+        agent=agent,
+        pipeline=pipeline
+    )
+    
+    @pipeline.on("user_turn_start")
+    async def on_user_turn_start(transcript: str):
+        logging.info(f"[USER TURN START] {transcript}")
+        
+    @pipeline.on("agent_turn_start")
+    async def on_agent_turn_start():
+        logging.info("[AGENT TURN START]")
+
+    @pipeline.on("agent_turn_end")
+    async def on_agent_turn_end():
+        logging.info("[AGENT TURN END]")
+
+    @pipeline.on("user_turn_end")
+    async def on_user_turn_end():
+        logging.info("[USER TURN END]")     
+        
+    @pipeline.on("llm")
+    async def on_agent_text(data: dict):
+        print(f"agent said: {data['text']}")
+        text = (data.get("text") or "").lower()
+        logging.info(f"[LLM] Generated {text[:100]}...")
+        if not any(phrase in text for phrase in FAREWELL_PHRASES):
+            return
+        logging.info("Farewell detected — will hang up after TTS playback")
+        handle = agent.session.current_utterance
+
+        async def _hangup_after_playback():
+            if handle and not handle.done():
+                await handle
+            await agent.hangup()
+
+        asyncio.create_task(_hangup_after_playback())
+        
+    await session.start(wait_for_participant=True, run_until_shutdown=True)
+
+def make_context() -> JobContext:
+    room_options = RoomOptions(
+        room_id="<room_id>", # Replace it with your actual room_id
+        name="Gemini Realtime Agent",
+        playground=True,
+    )
+
+    return JobContext(room_options=room_options)
+
+if __name__ == "__main__":
+    job = WorkerJob(entrypoint=start_session, jobctx=make_context)
+    job.start()

--- a/videosdk-agents/videosdk/agents/pipeline.py
+++ b/videosdk-agents/videosdk/agents/pipeline.py
@@ -867,7 +867,8 @@ class Pipeline(EventEmitter[Literal["start", "error", "transcript_ready", "conte
                     self.llm.on_user_speech_ended(lambda data: asyncio.create_task(self._on_user_speech_ended_realtime(data)))
                     self.llm.on_agent_speech_started(lambda data: asyncio.create_task(self._on_agent_speech_started_realtime(data)))
                     # self.llm.on_agent_speech_ended(lambda data: self._on_agent_speech_ended_realtime(data))
-                    self.llm.on_transcription(self._on_realtime_transcription)            
+                    self.llm.on_transcription(self._on_realtime_transcription)
+                    self.llm.on("llm_text_output", lambda data: asyncio.create_task(self._on_realtime_llm_text_output(data)))
             if self.config.realtime_mode == RealtimeMode.HYBRID_STT and self.orchestrator:
                 await self.orchestrator.start()
                 logger.info("Started orchestrator for hybrid_stt mode")
@@ -1081,6 +1082,12 @@ class Pipeline(EventEmitter[Literal["start", "error", "transcript_ready", "conte
             self.agent.session._emit_user_state(UserState.LISTENING)
             if self.agent.session.is_background_audio_enabled:
                 await self.agent.session.stop_thinking_audio()
+
+        if self.hooks and self.hooks.has_agent_turn_start_hooks():
+            try:
+                await self.hooks.trigger_agent_turn_start()
+            except Exception as e:
+                logger.error(f"Error in realtime agent_turn_start hook: {e}", exc_info=True)
     
     def _on_agent_speech_ended_realtime(self, data: dict) -> None:
         """Handle agent speech ended in realtime mode"""
@@ -1102,6 +1109,27 @@ class Pipeline(EventEmitter[Literal["start", "error", "transcript_ready", "conte
         if self.agent and hasattr(self.agent, 'on_agent_speech_ended'):
             self.agent.on_agent_speech_ended(data)
 
+        if self.hooks and self.hooks.has_agent_turn_end_hooks():
+            asyncio.create_task(self.hooks.trigger_agent_turn_end())
+        if self.hooks and self.hooks.has_user_turn_end_hooks():
+            asyncio.create_task(self.hooks.trigger_user_turn_end())
+
+    async def _on_realtime_llm_text_output(self, data: dict) -> None:
+        """Fire @pipeline.on('llm') observation hooks in realtime mode.
+
+        The hook return value cannot
+        affect TTS here — audio is already streaming from the realtime model.
+        """
+        if not (self.hooks and self.hooks.has_llm_hooks()):
+            return
+        text = data.get("text", "")
+        if not text:
+            return
+        try:
+            await self.hooks.trigger_llm({"text": text})
+        except Exception as e:
+            logger.error(f"Error in realtime LLM hook: {e}", exc_info=True)
+
     def _on_realtime_transcription(self, data: dict) -> None:
         """Handle realtime model transcription"""
         self.emit("realtime_model_transcription", data)
@@ -1120,6 +1148,9 @@ class Pipeline(EventEmitter[Literal["start", "error", "transcript_ready", "conte
                     self.agent.chat_context.add_message(
                         role=target_role, content=text,
                     )
+
+                if role == "user" and self.hooks and self.hooks.has_user_turn_start_hooks():
+                    asyncio.create_task(self.hooks.trigger_user_turn_start(text))
 
         if self.voice_mail_detector:
             pass


### PR DESCRIPTION
- Add `llm` and turn-related hook support to the realtime (S2S) pipeline, bringing it to parity with the cascade pipeline's hook system.
- Lets users track the state of both user and agent turns, and access the user/agent transcripts directly from the hook callbacks - without needing to subscribe to lower-level realtime events.

**Supported hooks (now firing in realtime mode):**

```python
@pipeline.on("llm")                # full agent transcript per turn
@pipeline.on("user_turn_start")    # user's final transcript (pre-agent-response)
@pipeline.on("user_turn_end")      # full turn complete (after agent finishes)
@pipeline.on("agent_turn_start")   # agent starts speaking
@pipeline.on("agent_turn_end")     # agent finishes speaking
``` 
Example:

```python

@pipeline.on("user_turn_start")
async def on_user_turn_start(transcript: str):
    logging.info(f"[USER] {transcript}")

@pipeline.on("llm")
async def on_llm(data: dict):
    logging.info(f"[AGENT] {data['text']}")
    
```      
Same hook code now works unchanged across cascade, realtime.