### PR TITLE
Add support for XAI’s STT and TTS

### DIFF
--- a/videosdk-plugins/videosdk-plugins-xai/README.md
+++ b/videosdk-plugins/videosdk-plugins-xai/README.md
@@ -1,6 +1,6 @@
 # VideoSDK xAI (Grok) Plugin
 
-Agent Framework plugin providing real-time voice (S2S) services by xAI (Grok).
+Agent Framework plugin for real-time voice (S2S), LLM, STT, and TTS  services by xAI (Grok).
 
 ## Installation
 

--- a/videosdk-plugins/videosdk-plugins-xai/videosdk/plugins/xai/__init__.py
+++ b/videosdk-plugins/videosdk-plugins-xai/videosdk/plugins/xai/__init__.py
@@ -1,4 +1,13 @@
 from .xai_realtime import XAIRealtime, XAIRealtimeConfig, XAITurnDetection
 from .llm import XAILLM
+from .stt import XAISTT
+from .tts import XAITTS
 
-__all__ = ["XAIRealtime", "XAIRealtimeConfig", "XAITurnDetection", "XAILLM"]
+__all__ = [
+    "XAIRealtime",
+    "XAIRealtimeConfig",
+    "XAITurnDetection",
+    "XAILLM",
+    "XAISTT",
+    "XAITTS",
+]

--- a/videosdk-plugins/videosdk-plugins-xai/videosdk/plugins/xai/stt.py
+++ b/videosdk-plugins/videosdk-plugins-xai/videosdk/plugins/xai/stt.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Literal, Optional
+from urllib.parse import urlencode
+
+import aiohttp
+import numpy as np
+
+from videosdk.agents import (
+    STT as BaseSTT,
+    STTResponse,
+    SpeechData,
+    SpeechEventType,
+)
+
+logger = logging.getLogger(__name__)
+
+XAI_STT_BASE_URL = "wss://api.x.ai/v1/stt"
+SUPPORTED_SAMPLE_RATES = {8000, 16000, 22050, 24000, 44100, 48000}
+SUPPORTED_ENCODINGS = {"pcm", "mulaw", "alaw"}
+_SILENCE_BYTE = {"pcm": b"\x00", "mulaw": b"\xff", "alaw": b"\xd5"}
+
+
+class XAISTT(BaseSTT):
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        sample_rate: int = 48000,
+        encoding: Literal["pcm", "mulaw", "alaw"] = "pcm",
+        interim_results: bool = True,
+        endpointing: int = 50,
+        language: str | None = "en",
+        diarize: bool = False,
+        multichannel: bool = False,
+        channels: int = 1,
+        base_url: str = XAI_STT_BASE_URL,
+    ) -> None:
+        """Initialize the xAI STT plugin.
+
+        Args:
+            api_key: xAI API key. Falls back to XAI_API_KEY env var.
+            sample_rate: Audio sample rate in Hz. xAI accepts 8000/16000/22050/24000/44100/48000.
+                Defaults to 48000 to match the framework's native input rate.
+            encoding: Raw audio encoding. One of "pcm" (signed 16-bit LE), "mulaw", "alaw".
+            interim_results: Emit partial transcripts (is_final=false) as they arrive.
+            endpointing: Silence duration (ms) before xAI fires utterance-final. Range 0–5000.
+                Kept low (50ms default) because the framework's VAD is the primary turn
+                detector; flush() injects synthetic silence to force utterance-final, and
+                a low threshold means flush latency is short.
+            language: BCP-47 language code (e.g. "en", "fr"). Pass None to skip the param.
+                xAI transcribes any supported language regardless of this — the value only
+                enables Inverse Text Normalization (numbers, currencies in written form).
+            diarize: When true, each word in the response includes a `speaker` field.
+            multichannel: When true, transcribes each input channel independently. Requires
+                interleaved multi-channel audio. When false, input is downmixed to mono.
+            channels: Number of input channels (only relevant with multichannel=True).
+            base_url: WebSocket endpoint URL.
+        """
+        super().__init__()
+
+        self.api_key = api_key or os.getenv("XAI_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "xAI API key must be provided either through the api_key parameter "
+                "or the XAI_API_KEY environment variable"
+            )
+
+        if sample_rate not in SUPPORTED_SAMPLE_RATES:
+            raise ValueError(
+                f"sample_rate must be one of {sorted(SUPPORTED_SAMPLE_RATES)}, got {sample_rate}"
+            )
+        if encoding not in SUPPORTED_ENCODINGS:
+            raise ValueError(
+                f"encoding must be one of {sorted(SUPPORTED_ENCODINGS)}, got {encoding}"
+            )
+        if not 0 <= endpointing <= 5000:
+            raise ValueError(f"endpointing must be in [0, 5000], got {endpointing}")
+
+        self.sample_rate = sample_rate
+        self.encoding = encoding
+        self.interim_results = interim_results
+        self.endpointing = endpointing
+        self.language = language
+        self.diarize = diarize
+        self.multichannel = multichannel
+        self.channels = channels
+        self.base_url = base_url
+
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._ws: Optional[aiohttp.ClientWebSocketResponse] = None
+        self._ws_task: Optional[asyncio.Task] = None
+        self._server_ready: asyncio.Event = asyncio.Event()
+        self._closed = False
+
+    async def process_audio(
+        self,
+        audio_frames: bytes,
+        language: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Process audio frames and stream them to xAI's WebSocket STT API."""
+        if self._closed:
+            return
+
+        if not self._ws:
+            await self._connect_ws()
+            self._ws_task = asyncio.create_task(self._listen_for_responses())
+            try:
+                await asyncio.wait_for(self._server_ready.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                self.emit("error", "Timed out waiting for xAI transcript.created")
+                return
+
+        try:
+            audio_bytes = audio_frames
+            if (
+                not self.multichannel
+                and self.encoding == "pcm"
+                and len(audio_frames) % 4 == 0
+            ):
+                audio_data = np.frombuffer(audio_frames, dtype=np.int16)
+                if audio_data.size > 0 and audio_data.size % 2 == 0:
+                    audio_data = (
+                        audio_data.reshape(-1, 2).mean(axis=1).astype(np.int16)
+                    )
+                    audio_bytes = audio_data.tobytes()
+
+            await self._ws.send_bytes(audio_bytes)
+        except Exception as e:
+            logger.error(f"Error sending audio to xAI STT: {e}")
+            self.emit("error", str(e))
+            await self._reset_connection()
+
+    async def _connect_ws(self) -> None:
+        """Open the WebSocket connection to xAI's STT endpoint."""
+        if not self._session:
+            self._session = aiohttp.ClientSession()
+
+        params: list[tuple[str, str]] = [
+            ("sample_rate", str(self.sample_rate)),
+            ("encoding", self.encoding),
+            ("interim_results", str(self.interim_results).lower()),
+            ("endpointing", str(self.endpointing)),
+            ("diarize", str(self.diarize).lower()),
+            ("multichannel", str(self.multichannel).lower()),
+            ("channels", str(1 if not self.multichannel else self.channels)),
+        ]
+        if self.language:
+            params.append(("language", self.language))
+
+        ws_url = f"{self.base_url}?{urlencode(params)}"
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+
+        self._server_ready = asyncio.Event()
+
+        try:
+            self._ws = await self._session.ws_connect(
+                ws_url, headers=headers, heartbeat=30.0
+            )
+        except Exception as e:
+            logger.error(f"Error connecting to xAI STT WebSocket: {e}")
+            raise
+
+    async def _listen_for_responses(self) -> None:
+        """Background task that reads transcript events from the WebSocket."""
+        if not self._ws:
+            return
+
+        try:
+            async for msg in self._ws:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    try:
+                        data = msg.json()
+                    except Exception as e:
+                        logger.error(f"Failed to parse xAI STT message: {e}")
+                        continue
+
+                    event_type = data.get("type")
+                    if event_type == "transcript.created":
+                        self._server_ready.set()
+                    elif event_type == "transcript.partial":
+                        response = self._handle_partial(data)
+                        if response and self._transcript_callback:
+                            await self._transcript_callback(response)
+                    elif event_type == "transcript.done":
+                        response = self._handle_partial(data)
+                        if response and self._transcript_callback:
+                            await self._transcript_callback(response)
+                    elif event_type == "error":
+                        message = data.get("message", "unknown error")
+                        logger.error(f"xAI STT error event: {message}")
+                        self.emit("error", message)
+                elif msg.type == aiohttp.WSMsgType.ERROR:
+                    err = self._ws.exception()
+                    logger.error(f"xAI STT WebSocket error: {err}")
+                    self.emit("error", f"WebSocket error: {err}")
+                    break
+                elif msg.type == aiohttp.WSMsgType.CLOSED:
+                    break
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"Error in xAI STT listener: {e}")
+            self.emit("error", f"Error in WebSocket listener: {e}")
+        finally:
+            if self._ws and not self._ws.closed:
+                await self._ws.close()
+            self._ws = None
+            self._server_ready.clear()
+
+    def _handle_partial(self, event: dict) -> Optional[STTResponse]:
+        """Map an xAI transcript event to an STTResponse."""
+        text = event.get("text", "")
+        if not text:
+            return None
+
+        is_final = bool(event.get("is_final", False))
+        speech_final = bool(event.get("speech_final", False))
+        event_is_done = event.get("type") == "transcript.done"
+        event_type = (
+            SpeechEventType.FINAL
+            if (is_final and speech_final) or event_is_done
+            else SpeechEventType.INTERIM
+        )
+
+        words = event.get("words") or []
+        start = event.get("start", 0.0) or 0.0
+        duration = event.get("duration", 0.0) or 0.0
+        if words:
+            start_time = float(words[0].get("start", start))
+            end_time = float(words[-1].get("end", start + duration))
+        else:
+            start_time = float(start)
+            end_time = float(start) + float(duration)
+
+        return STTResponse(
+            event_type=event_type,
+            data=SpeechData(
+                text=text,
+                language=self.language,
+                confidence=0.0,
+                start_time=start_time,
+                end_time=end_time,
+                duration=float(duration),
+            ),
+            metadata={
+                "is_final": is_final,
+                "speech_final": speech_final,
+                "channel_index": event.get("channel_index"),
+            },
+        )
+
+    async def flush(self) -> None:
+        """Force xAI to emit the current utterance-final transcript.
+
+        We inject a short chunk of silence bytes — once the configured
+        endpointing window elapses, xAI fires `transcript.partial` with
+        speech_final=true, which we map to SpeechEventType.FINAL.
+        """
+        if self._closed or not self._ws or self._ws.closed:
+            return
+        if not self._server_ready.is_set():
+            return
+
+        try:
+            silence_ms = max(self.endpointing + 50, 100)
+            bytes_per_sample = 2 if self.encoding == "pcm" else 1
+            channel_count = self.channels if self.multichannel else 1
+            n_bytes = int(
+                self.sample_rate * bytes_per_sample * channel_count * silence_ms / 1000
+            )
+            silence = _SILENCE_BYTE[self.encoding] * n_bytes
+            await self._ws.send_bytes(silence)
+        except Exception as e:
+            logger.warning(f"xAI STT flush failed: {e}")
+
+    async def _reset_connection(self) -> None:
+        if self._ws:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+        if self._ws_task:
+            self._ws_task.cancel()
+            try:
+                await self._ws_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._ws_task = None
+        self._server_ready.clear()
+
+    async def aclose(self) -> None:
+        """Cleanup resources."""
+        self._closed = True
+
+        if self._ws and not self._ws.closed:
+            try:
+                await self._ws.send_str(json.dumps({"type": "audio.done"}))
+            except Exception:
+                pass
+
+        if self._ws_task:
+            self._ws_task.cancel()
+            try:
+                await self._ws_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._ws_task = None
+
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None
+
+        if self._session:
+            await self._session.close()
+            self._session = None
+
+        await super().aclose()

--- a/videosdk-plugins/videosdk-plugins-xai/videosdk/plugins/xai/tts.py
+++ b/videosdk-plugins/videosdk-plugins-xai/videosdk/plugins/xai/tts.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+from typing import Any, AsyncIterator, Literal, Optional
+from urllib.parse import urlencode
+
+import aiohttp
+
+from videosdk.agents import TTS
+
+logger = logging.getLogger(__name__)
+
+XAI_TTS_BASE_URL = "wss://api.x.ai/v1/tts"
+XAI_TTS_NUM_CHANNELS = 1
+SUPPORTED_VOICES = {"eve", "ara", "rex", "sal", "leo"}
+SUPPORTED_SAMPLE_RATES = {8000, 16000, 22050, 24000, 44100, 48000}
+
+SUPPORTED_CODECS = {"pcm", "mulaw"}
+
+
+class XAITTS(TTS):
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        voice: str = "eve",
+        language: str = "en",
+        codec: Literal["pcm", "mulaw"] = "pcm",
+        sample_rate: int = 24000,
+        optimize_streaming_latency: int = 0,
+        text_normalization: bool = False,
+        base_url: str = XAI_TTS_BASE_URL,
+    ) -> None:
+        """Initialize the xAI TTS plugin.
+
+        Args:
+            api_key: xAI API key. Falls back to XAI_API_KEY env var.
+            voice: Voice ID — one of "eve", "ara", "rex", "sal", "leo". Case-insensitive.
+            language: BCP-47 language code (e.g. "en", "fr", "pt-BR") or "auto" for
+                automatic language detection. Required by xAI.
+            codec: Output codec. Restricted to "pcm" (signed 16-bit LE, default) or
+                "mulaw" — both are raw, byte-streamable formats compatible with the
+                framework's audio_track. mp3/wav/alaw are not exposed because they
+                require a decoder before bytes can be played.
+            sample_rate: Output sample rate in Hz. One of 8000/16000/22050/24000/44100/48000.
+                Defaults to 24000 (xAI's recommended rate).
+            optimize_streaming_latency: 0 (default, best quality) or 1 (lower
+                time-to-first-audio with minor quality tradeoff).
+            text_normalization: When true, xAI normalizes written-form text
+                (numbers, abbreviations, symbols) into spoken-form before synthesis.
+            base_url: WebSocket endpoint URL.
+
+        Speech tags:
+            xAI supports inline expression tags ([pause], [long-pause], [laugh],
+            [sigh], [breath], etc.) and wrapping style tags (<whisper>...</whisper>,
+            <soft>, <loud>, <slow>, <fast>, <higher-pitch>, <lower-pitch>,
+            <emphasis>, <singing>, <sing-song>, <laugh-speak>, <build-intensity>,
+            <decrease-intensity>) directly inside the `text` you pass to
+            `synthesize()`. No separate parameter is needed — the tags are sent
+            verbatim as part of each text.delta message and parsed server-side.
+
+            Example::
+
+                await tts.synthesize(
+                    "So I walked in and [pause] there it was. [laugh] Incredible!"
+                )
+                await tts.synthesize(
+                    "I need to tell you something. "
+                    "<whisper>It is a secret.</whisper> Pretty cool, right?"
+                )
+
+            Caveat for streaming input: when synthesize() receives an
+            AsyncIterator[str] (e.g. LLM tokens), a single tag can be split across
+            two chunks ("[pa", "use]") which xAI will not recognize. Tags only work
+            reliably when an entire tag arrives within one text chunk.
+        """
+        if sample_rate not in SUPPORTED_SAMPLE_RATES:
+            raise ValueError(
+                f"sample_rate must be one of {sorted(SUPPORTED_SAMPLE_RATES)}, got {sample_rate}"
+            )
+        if codec not in SUPPORTED_CODECS:
+            raise ValueError(
+                f"codec must be one of {sorted(SUPPORTED_CODECS)} for raw PCM-compatible "
+                f"output (got {codec}). mp3/wav/alaw are not supported because they "
+                f"produce framed audio that the audio_track cannot consume directly."
+            )
+        if optimize_streaming_latency not in (0, 1):
+            raise ValueError("optimize_streaming_latency must be 0 or 1")
+
+        super().__init__(
+            sample_rate=sample_rate,
+            num_channels=XAI_TTS_NUM_CHANNELS,
+            word_timestamps=False,
+        )
+
+        self._api_key = api_key or os.getenv("XAI_API_KEY")
+        if not self._api_key:
+            raise ValueError(
+                "xAI API key must be provided either through the api_key parameter "
+                "or the XAI_API_KEY environment variable"
+            )
+
+        voice_lower = voice.lower()
+        if voice_lower not in SUPPORTED_VOICES:
+            raise ValueError(
+                f"voice must be one of {sorted(SUPPORTED_VOICES)}, got {voice}"
+            )
+
+        self._voice = voice_lower
+        self.language = language
+        self.codec = codec
+        self.optimize_streaming_latency = optimize_streaming_latency
+        self.text_normalization = text_normalization
+        self.base_url = base_url
+
+        self._ws_session: Optional[aiohttp.ClientSession] = None
+        self._ws_connection: Optional[aiohttp.ClientWebSocketResponse] = None
+        self._connection_lock = asyncio.Lock()
+        self._synthesis_lock = asyncio.Lock()
+        self._receive_task: Optional[asyncio.Task] = None
+        self._current_done_future: Optional[asyncio.Future[None]] = None
+        self._first_chunk_sent = False
+        self._interrupted = False
+        self._closed = False
+
+    def reset_first_audio_tracking(self) -> None:
+        """Reset the first-audio-byte tracking state for the next synthesis turn."""
+        self._first_chunk_sent = False
+
+    async def synthesize(
+        self,
+        text: AsyncIterator[str] | str,
+        voice_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Synthesize text to speech via xAI's bidirectional WebSocket API."""
+        try:
+            if not self.audio_track or not self.loop:
+                self.emit("error", "Audio track or event loop not set")
+                return
+
+            if voice_id:
+                voice_lower = voice_id.lower()
+                if voice_lower not in SUPPORTED_VOICES:
+                    self.emit(
+                        "error",
+                        f"voice_id must be one of {sorted(SUPPORTED_VOICES)}, got {voice_id}",
+                    )
+                    return
+                self._voice = voice_lower
+
+            async with self._synthesis_lock:
+                self._interrupted = False
+                self._first_chunk_sent = False
+
+                await self._ensure_ws_connection()
+                if not self._ws_connection:
+                    raise RuntimeError("WebSocket connection is not available.")
+
+                done_future: asyncio.Future[None] = (
+                    asyncio.get_event_loop().create_future()
+                )
+                self._current_done_future = done_future
+
+                async def _string_iterator(s: str) -> AsyncIterator[str]:
+                    yield s
+
+                text_iterator = (
+                    _string_iterator(text) if isinstance(text, str) else text
+                )
+
+                send_task = asyncio.create_task(
+                    self._send_task(text_iterator, done_future)
+                )
+
+                try:
+                    await done_future
+                finally:
+                    if not send_task.done():
+                        try:
+                            await send_task
+                        except Exception:
+                            pass
+
+        except Exception as e:
+            self.emit("error", f"TTS synthesis failed: {e}")
+            raise
+        finally:
+            self._current_done_future = None
+
+    async def _send_task(
+        self,
+        text_iterator: AsyncIterator[str],
+        done_future: asyncio.Future[None],
+    ) -> None:
+        """Send text.delta messages, then text.done at end of utterance."""
+        has_sent = False
+        try:
+            async for chunk in text_iterator:
+                if self._interrupted:
+                    break
+                if not chunk or not chunk.strip():
+                    continue
+                if not self._ws_connection or self._ws_connection.closed:
+                    break
+                payload = {"type": "text.delta", "delta": chunk}
+                await self._ws_connection.send_str(json.dumps(payload))
+                has_sent = True
+        except Exception as e:
+            if not done_future.done():
+                done_future.set_exception(e)
+            return
+        finally:
+            if (
+                has_sent
+                and not self._interrupted
+                and self._ws_connection
+                and not self._ws_connection.closed
+            ):
+                try:
+                    await self._ws_connection.send_str(
+                        json.dumps({"type": "text.done"})
+                    )
+                except Exception as e:
+                    if not done_future.done():
+                        done_future.set_exception(e)
+
+        if not has_sent and not done_future.done():
+            done_future.set_result(None)
+
+    async def _receive_loop(self) -> None:
+        """Long-running task: read audio.delta / audio.done / error frames."""
+        try:
+            while self._ws_connection and not self._ws_connection.closed:
+                msg = await self._ws_connection.receive()
+                if msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING):
+                    break
+                if msg.type == aiohttp.WSMsgType.ERROR:
+                    err = self._ws_connection.exception()
+                    self._fail_pending(RuntimeError(f"xAI TTS WebSocket error: {err}"))
+                    break
+                if msg.type != aiohttp.WSMsgType.TEXT:
+                    continue
+
+                try:
+                    data = json.loads(msg.data)
+                except Exception as e:
+                    logger.error(f"Failed to parse xAI TTS message: {e}")
+                    continue
+
+                event_type = data.get("type")
+                if event_type == "audio.delta":
+                    delta = data.get("delta")
+                    if delta:
+                        try:
+                            await self._stream_audio(base64.b64decode(delta))
+                        except Exception as e:
+                            logger.error(f"Failed to decode/stream audio: {e}")
+                elif event_type == "audio.done":
+                    future = self._current_done_future
+                    if future and not future.done():
+                        future.set_result(None)
+                elif event_type == "error":
+                    message = data.get("message", "unknown error")
+                    self._fail_pending(RuntimeError(f"xAI TTS error: {message}"))
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self._fail_pending(e)
+
+    def _fail_pending(self, exc: BaseException) -> None:
+        future = self._current_done_future
+        if future and not future.done():
+            future.set_exception(exc)
+
+    async def _stream_audio(self, audio_chunk: bytes) -> None:
+        """Push a chunk of raw audio bytes into the framework's audio_track."""
+        if self._interrupted or not audio_chunk:
+            return
+
+        if not self._first_chunk_sent:
+            self._first_chunk_sent = True
+            if self._first_audio_callback:
+                await self._first_audio_callback()
+
+        if self.audio_track:
+            await self.audio_track.add_new_bytes(audio_chunk)
+
+    async def _ensure_ws_connection(self) -> None:
+        """Open or re-open the WebSocket connection if needed."""
+        async with self._connection_lock:
+            if self._ws_connection and not self._ws_connection.closed:
+                return
+
+            if self._receive_task and not self._receive_task.done():
+                self._receive_task.cancel()
+                try:
+                    await self._receive_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+            self._receive_task = None
+
+            if self._ws_connection:
+                try:
+                    await self._ws_connection.close()
+                except Exception:
+                    pass
+                self._ws_connection = None
+
+            if self._ws_session:
+                try:
+                    await self._ws_session.close()
+                except Exception:
+                    pass
+                self._ws_session = None
+
+            try:
+                self._ws_session = aiohttp.ClientSession()
+
+                params = [
+                    ("voice", self._voice),
+                    ("language", self.language),
+                    ("codec", self.codec),
+                    ("sample_rate", str(self.sample_rate)),
+                    ("optimize_streaming_latency", str(self.optimize_streaming_latency)),
+                    ("text_normalization", str(self.text_normalization).lower()),
+                ]
+                ws_url = f"{self.base_url}?{urlencode(params)}"
+                headers = {"Authorization": f"Bearer {self._api_key}"}
+
+                self._ws_connection = await asyncio.wait_for(
+                    self._ws_session.ws_connect(
+                        ws_url, headers=headers, heartbeat=30.0
+                    ),
+                    timeout=5.0,
+                )
+                self._receive_task = asyncio.create_task(self._receive_loop())
+            except aiohttp.WSServerHandshakeError as e:
+                self.emit(
+                    "error",
+                    f"xAI TTS WebSocket handshake failed (status {e.status}): {e.message}",
+                )
+                raise
+            except Exception as e:
+                self.emit("error", f"Failed to establish xAI TTS WebSocket: {e}")
+                raise
+
+    async def interrupt(self) -> None:
+        """Interrupt any in-flight synthesis and clear the audio_track buffer."""
+        self._interrupted = True
+
+        if self.audio_track:
+            self.audio_track.interrupt()
+
+        future = self._current_done_future
+        if future and not future.done():
+            future.set_result(None)
+
+        if self._ws_connection and not self._ws_connection.closed:
+            try:
+                await self._ws_connection.close()
+            except Exception:
+                pass
+
+    async def aclose(self) -> None:
+        """Gracefully clean up all resources."""
+        await super().aclose()
+        self._interrupted = True
+        self._closed = True
+
+        if self._receive_task and not self._receive_task.done():
+            self._receive_task.cancel()
+            try:
+                await self._receive_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._receive_task = None
+
+        if self._ws_connection and not self._ws_connection.closed:
+            await self._ws_connection.close()
+        self._ws_connection = None
+
+        if self._ws_session and not self._ws_session.closed:
+            await self._ws_session.close()
+        self._ws_session = None


### PR DESCRIPTION
- Add XAISTT - WebSocket streaming STT
- Add XAITTS - WebSocket synth


from videosdk.plugins.xai import XAISTT, XAITTS
```python
stt = XAISTT(
    api_key=os.getenv("XAI_API_KEY"),  # falls back to env var if omitted
    language="en",                     # BCP-47; enables ITN, not language gating
    diarize=False,                     # per-word speaker labels
    multichannel=False,                # transcribe each channel independently
    channels=1,                        # only used when multichannel=True
)
tts = XAITTS(
    api_key=os.getenv("XAI_API_KEY"),
    voice="eve",                       # eve | ara | rex | sal | leo
    language="en",                     # BCP-47 or "auto"
    text_normalization=False,          # spoken-form normalization server-side
)
```

Expressive synthesis using inline tags (sent verbatim inside text, parsed server-side): 

```
await session.say(
    "So I walked in and [pause] there it was. [laugh] Incredible! "
    "<whisper>Do not tell anyone.</whisper>"
)
```