### PR TITLE
fix(wakeup): cancel orphan timers and fix interrupt race

### DIFF
--- a/videosdk-agents/videosdk/agents/agent_session.py
+++ b/videosdk-agents/videosdk/agents/agent_session.py
@@ -126,9 +126,11 @@ class AgentSession(EventEmitter[Literal["user_state_changed", "agent_state_chang
 
     def _start_wake_up_timer(self) -> None:
         if self.wake_up is not None and self.on_wake_up is not None:
+            if self._wake_up_task and not self._wake_up_task.done():
+                self._wake_up_task.cancel()
             self._wake_up_timer_active = True
             self._wake_up_task = asyncio.create_task(self._wake_up_timer_loop())
-    
+
     def _reset_wake_up_timer(self) -> None:
         if self.wake_up is not None and self.on_wake_up is not None:
             if self._reply_in_progress:
@@ -137,8 +139,9 @@ class AgentSession(EventEmitter[Literal["user_state_changed", "agent_state_chang
                 self._wake_up_task.cancel()
             self._wake_up_timer_active = True
             self._wake_up_task = asyncio.create_task(self._wake_up_timer_loop())
-    
+
     def _pause_wake_up_timer(self) -> None:
+        self._wake_up_timer_active = False
         if self._wake_up_task and not self._wake_up_task.done():
             self._wake_up_task.cancel()
     
@@ -150,7 +153,12 @@ class AgentSession(EventEmitter[Literal["user_state_changed", "agent_state_chang
     async def _wake_up_timer_loop(self) -> None:
         try:
             await asyncio.sleep(self.wake_up)
-            if self._wake_up_timer_active and self.on_wake_up and not self._reply_in_progress:
+            if (
+                self._wake_up_timer_active
+                and self.on_wake_up
+                and not self._reply_in_progress
+                and self._user_state != UserState.SPEAKING
+            ):
                 if asyncio.iscoroutinefunction(self.on_wake_up):
                     asyncio.create_task(self.on_wake_up())
                 else:

--- a/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
+++ b/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
@@ -431,7 +431,14 @@ class PipelineOrchestrator(EventEmitter[Literal[
         self._is_user_speaking = True
 
         agent_state = self.agent.session.agent_state if self.agent and self.agent.session else None
-        if agent_state == AgentState.SPEAKING:
+        cu = self.agent.session.current_utterance if self.agent and self.agent.session else None
+        is_synthesizing = bool(self.speech_generation and self.speech_generation.tts_lock.locked())
+        is_agent_active = (
+            agent_state in (AgentState.SPEAKING, AgentState.THINKING)
+            or (cu is not None and not cu.done())
+            or is_synthesizing
+        )
+        if is_agent_active:
             if self._interruption_check_task is None or self._interruption_check_task.done():
                 logger.info("User started speaking during agent response, initiating interruption monitoring")
                 self._interruption_check_task = asyncio.create_task(


### PR DESCRIPTION
- Cancel existing timer before re-arming to avoid orphan tasks
- Reset active flag on pause for safety
- Skip timer firing while user is speaking
- Arm VAD interrupt during speech/TTS to prevent missed interrupts