### PR TITLE
Fix: agent speech interruption handling

### DIFF
--- a/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
+++ b/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
@@ -609,6 +609,10 @@ class PipelineOrchestrator(EventEmitter[Literal[
         self._is_interrupted = False
         full_response = ""
         self._partial_response = ""
+
+        if self.speech_generation:
+            self.speech_generation.spoken_transcript = ""
+        
         
         try:
             if self.agent and self.agent.session and self.agent.session.is_background_audio_enabled:
@@ -772,8 +776,16 @@ class PipelineOrchestrator(EventEmitter[Literal[
                     full_response = new_response
 
             if self._is_interrupted or self._generation_id != my_generation_id:
-                logger.info("[orchestrator] Skipping post-gather updates — turn was interrupted or generation superseded")
+                logger.info(
+                    "[ctx-add] SKIP post-gather add (gen_id=%s my_gen_id=%s is_interrupted=%s partial_len=%d full_len=%d)",
+                    self._generation_id, my_generation_id, self._is_interrupted,
+                    len(self._partial_response or ""), len(full_response or ""),
+                )
             elif full_response and self.agent:
+                logger.info(
+                    "[ctx-add] SITE-A post-gather add (gen_id=%s is_interrupted=%s len=%d preview=%r)",
+                    my_generation_id, self._is_interrupted, len(full_response), full_response[:80],
+                )
                 self.agent.chat_context.add_message(
                     role=ChatRole.ASSISTANT,
                     content=full_response
@@ -1110,6 +1122,10 @@ class PipelineOrchestrator(EventEmitter[Literal[
     
     async def _interrupt_pipeline(self) -> None:
         """Interrupt all components"""
+        logger.info(
+            "[ctx-add] _interrupt_pipeline ENTER (gen_id=%s already_interrupted=%s partial_len=%d)",
+            self._generation_id, self._is_interrupted, len(self._partial_response or ""),
+        )
         self.agent.session._emit_agent_state(AgentState.LISTENING)
         self._is_interrupted = True
         self._cancel_false_interrupt_timer()
@@ -1135,20 +1151,46 @@ class PipelineOrchestrator(EventEmitter[Literal[
         if self._current_generation_task and not self._current_generation_task.done():
             self._current_generation_task.cancel()
 
-        if self._partial_response and metrics_collector.current_turn:
+        truncated_response = ""
+        source = "none"
+        sg_spoken_len = len(self.speech_generation.spoken_transcript) if self.speech_generation and self.speech_generation.spoken_transcript else 0
+        partial_len = len(self._partial_response or "")
+        if self.speech_generation and self.speech_generation.spoken_transcript:
+            truncated_response = self.speech_generation.spoken_transcript
+            source = "spoken_transcript"
+        elif self._partial_response:
+            truncated_response = self._partial_response
+            source = "partial_response(LLM)"
+        logger.info(
+            "[ctx-add] INTERRUPT source=%s spoken_len=%d partial_len=%d chosen_len=%d preview=%r",
+            source, sg_spoken_len, partial_len, len(truncated_response), truncated_response[:80],
+        )
+
+        if truncated_response and metrics_collector.current_turn:
             if not metrics_collector.current_turn.agent_speech:
-                metrics_collector.set_agent_response(self._partial_response)
+                metrics_collector.set_agent_response(truncated_response)
             else:
                 metrics_collector.emit_agent_transcript_transport(
                     metrics_collector.current_turn.agent_speech, type="final"
                 )
 
-        if self._partial_response and self.agent:
+        if truncated_response and self.agent:
+            last = self.agent.chat_context.items[-1] if self.agent.chat_context.items else None
+            last_info = (
+                f"role={getattr(last, 'role', None)} id={getattr(last, 'id', None)} "
+                f"len={len(getattr(last, 'content', '') or '') if isinstance(getattr(last, 'content', None), str) else 'list'}"
+                if last else "none"
+            )
+            logger.info(
+                "[ctx-add] SITE-B interrupt add (source=%s len=%d last_item=%s)",
+                source, len(truncated_response), last_info,
+            )
             msg = self.agent.chat_context.add_message(
                 role=ChatRole.ASSISTANT,
-                content=self._partial_response
+                content=truncated_response
             )
             msg.interrupted = True
+            logger.info("[ctx-add] SITE-B added msg id=%s interrupted=True", msg.id)
 
         if metrics_collector.current_turn:
             logger.info("[orchestrator] Completing interrupted turn")

--- a/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
+++ b/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
@@ -733,6 +733,13 @@ class PipelineOrchestrator(EventEmitter[Literal[
                             continue
 
                 if self.speech_generation:
+                    playback_done = asyncio.Event()
+
+                    def _on_playback_done(_data: Any = None) -> None:
+                        playback_done.set()
+
+                    self.speech_generation.on("last_audio_byte", _on_playback_done)
+                    self.speech_generation.on("synthesis_interrupted", _on_playback_done)
                     try:
                         text_source = tts_stream_gen()
                         if self._text_filter is not None:
@@ -746,9 +753,13 @@ class PipelineOrchestrator(EventEmitter[Literal[
                         if self.hooks:
                             text_source = self.hooks.process_llm_stream(text_source)
                         await self.speech_generation.synthesize(text_source)
+                        await playback_done.wait()
                     except asyncio.CancelledError:
                         if self.speech_generation:
                             await self.speech_generation.interrupt()
+                    finally:
+                        self.speech_generation.off("last_audio_byte", _on_playback_done)
+                        self.speech_generation.off("synthesis_interrupted", _on_playback_done)
             
             collector_task = asyncio.create_task(collector())
             tts_task = asyncio.create_task(tts_consumer())
@@ -784,7 +795,7 @@ class PipelineOrchestrator(EventEmitter[Literal[
             elif full_response and self.agent:
                 logger.info(
                     "[ctx-add] SITE-A post-gather add (gen_id=%s is_interrupted=%s len=%d preview=%r)",
-                    my_generation_id, self._is_interrupted, len(full_response), full_response[:80],
+                    my_generation_id, self._is_interrupted, len(full_response), full_response,
                 )
                 self.agent.chat_context.add_message(
                     role=ChatRole.ASSISTANT,

--- a/videosdk-agents/videosdk/agents/room/output_stream.py
+++ b/videosdk-agents/videosdk/agents/room/output_stream.py
@@ -52,10 +52,30 @@ class CustomAudioStreamTrack(CustomAudioTrack):
         self._accepting_audio = True
         self._manual_audio_control = False
 
+        self._samples_played: int = 0
+        self._cumulative_input_samples: int = 0
+        self._synthesis_start_played: int = 0
+        self._synthesis_start_pushed: int = 0
+
+
     @property
     def can_pause(self) -> bool:
         """Returns True if this track supports pause/resume operations"""
         return True
+    def mark_synthesis_start(self) -> None:
+        """Anchor the per-synthesis baseline for played/pushed sample counters.
+        Called by SpeechGeneration at the top of each synthesize() so that
+        snapshot_playback() returns deltas relative to this turn only.
+        """
+        self._synthesis_start_played = self._samples_played
+        self._synthesis_start_pushed = self._cumulative_input_samples
+
+    def snapshot_playback(self) -> tuple[int, int]:
+        """Return (samples_played, samples_pushed) deltas for the active synthesis."""
+        played = max(0, self._samples_played - self._synthesis_start_played)
+        pushed = max(0, self._cumulative_input_samples - self._synthesis_start_pushed)
+        return played, pushed
+
 
     def interrupt(self):
         """Clear all buffers and reset state"""
@@ -160,7 +180,7 @@ class CustomAudioStreamTrack(CustomAudioTrack):
         if not self._accepting_audio:
             logger.debug("Audio input currently disabled, dropping audio data")
             return
-        
+        self._cumulative_input_samples += len(audio_data) // (self.channels * self.sample_width)
         self.audio_data_buffer += audio_data
 
         while len(self.audio_data_buffer) >= self.chunk_size:
@@ -237,6 +257,7 @@ class CustomAudioStreamTrack(CustomAudioTrack):
                     p.update(bytes(p.buffer_size))
             elif len(self.frame_buffer) > 0:
                 frame = self.frame_buffer.pop(0)
+                self._samples_played += self.samples
                 self._is_speaking = True
                 self._last_speaking_time = time()
             else:
@@ -290,6 +311,7 @@ class MixingCustomAudioStreamTrack(CustomAudioStreamTrack):
 
     async def add_new_bytes(self, audio_data: bytes):
         """Overrides base method to buffer bytes instead of creating frames."""
+        self._cumulative_input_samples += len(audio_data) // (self.channels * self.sample_width)
         self.audio_data_buffer += audio_data
 
     async def add_background_bytes(self, audio_data: bytes):
@@ -342,6 +364,7 @@ class MixingCustomAudioStreamTrack(CustomAudioStreamTrack):
             if has_primary:
                 primary_chunk = self.audio_data_buffer[: self.chunk_size]
                 self.audio_data_buffer = self.audio_data_buffer[self.chunk_size :]
+                self._samples_played += self.samples
                 self._is_speaking = True
                 self._last_speaking_time = time()
             elif getattr(self, "_is_speaking", False):

--- a/videosdk-agents/videosdk/agents/speech_generation.py
+++ b/videosdk-agents/videosdk/agents/speech_generation.py
@@ -45,6 +45,9 @@ class SpeechGeneration(EventEmitter[Literal["synthesis_started", "first_audio_by
         self._is_interrupted = False
         self.full_transcript = ""
 
+        self.spoken_transcript: str = ""
+        self._tier2_spoken_transcript: str = ""
+
         if self.tts and getattr(self.tts, "supports_word_timestamps", False):
             try:
                 self.tts.on("word_spoken", self._on_tts_word_spoken)
@@ -57,10 +60,12 @@ class SpeechGeneration(EventEmitter[Literal["synthesis_started", "first_audio_by
         if not isinstance(data, dict):
             return
         cumulative = data.get("cumulative_text", "")
-        if cumulative and metrics_collector:
-            metrics_collector.emit_agent_transcript_transport(
-                cumulative, type="interim"
-            )
+        if cumulative:
+            self._tier2_spoken_transcript = cumulative
+            if metrics_collector:
+                metrics_collector.emit_agent_transcript_transport(
+                    cumulative, type="interim"
+                )
 
     def _on_final_agent_transcript(self, data: Any) -> None:
         """Emit the final agent transcript after playback completes.
@@ -99,6 +104,8 @@ class SpeechGeneration(EventEmitter[Literal["synthesis_started", "first_audio_by
 
             self.full_transcript = ""
             tts_start_recorded = False
+            self.spoken_transcript = ""
+            self._tier2_spoken_transcript = ""
             async def character_counting_wrapper(text_iterator: AsyncIterator[str]):
 
                 async for text_chunk in text_iterator:
@@ -132,6 +139,9 @@ class SpeechGeneration(EventEmitter[Literal["synthesis_started", "first_audio_by
                         if hasattr(self.agent.session.pipeline, "audio_track"):
                             self.audio_track = self.agent.session.pipeline.audio_track
                 
+                if self.audio_track and hasattr(self.audio_track, "mark_synthesis_start"):
+                    self.audio_track.mark_synthesis_start()
+
                 if self.audio_track and hasattr(self.audio_track, "enable_audio_input"):
                     self.audio_track.enable_audio_input(manual_control=True)
                 
@@ -206,6 +216,8 @@ class SpeechGeneration(EventEmitter[Literal["synthesis_started", "first_audio_by
                         self.audio_track = self.agent.session.pipeline.audio_track
                     else:
                         logger.warning("Audio track not found in pipeline - last audio callback will be skipped")
+            if self.audio_track and hasattr(self.audio_track, "mark_synthesis_start"):
+                self.audio_track.mark_synthesis_start()
             
             if self.audio_track and hasattr(self.audio_track, "enable_audio_input"):
                 self.audio_track.enable_audio_input(manual_control=True)
@@ -303,9 +315,34 @@ class SpeechGeneration(EventEmitter[Literal["synthesis_started", "first_audio_by
                 elif self.agent and self.agent.session:
                     self.agent.session._reply_in_progress = False
 
+    def compute_spoken_transcript(self) -> str:
+        """Best-effort estimate of the portion of full_transcript that was
+        actually played out to the listener at the moment of call.
+        """
+        if not self.full_transcript:
+            return ""
+        if self._tier2_spoken_transcript:
+            return self._tier2_spoken_transcript.strip()
+        if not self.audio_track or not hasattr(self.audio_track, "snapshot_playback"):
+            return ""
+        played, pushed = self.audio_track.snapshot_playback()
+        if pushed <= 0:
+            return ""
+        fraction = max(0.0, min(1.0, played / pushed))
+        char_cutoff = int(len(self.full_transcript) * fraction)
+        if char_cutoff <= 0:
+            return ""
+        truncated = self.full_transcript[:char_cutoff]
+
+        last_break = max(truncated.rfind(" "), truncated.rfind("\n"))
+        if last_break <= 0:
+            return ""
+        return truncated[:last_break].strip()
+    
     async def interrupt(self) -> None:
         """Interrupt the current synthesis"""
         self._is_interrupted = True
+        self.spoken_transcript = self.compute_spoken_transcript()
 
         if self.tts:
             await self.tts.interrupt()


### PR DESCRIPTION
Fix: Store only the spoken portion of interrupted assistant replies

- Previously, interrupted assistant replies were saved in full even if only some part was played back
- Now tracks actual audio playback to determine how much of the response was heard
- On interrupt, only the spoken portion is stored instead of the full reply
- Uses TTS events to build the spoken transcript, with proportional text trimming as a fallback
- Cleans up state on reset to prevent stale data from carrying over