### PR TITLE
Fix/minor bugs

### DIFF
--- a/videosdk-agents/videosdk/agents/agent_session.py
+++ b/videosdk-agents/videosdk/agents/agent_session.py
@@ -6,8 +6,8 @@ import uuid
 from .agent import Agent
 from .llm.chat_context import ChatRole
 from .pipeline import Pipeline
-from .utils import get_tool_info, UserState, AgentState
-from .utterance_handle import UtteranceHandle 
+from .utils import get_tool_info, UserState, AgentState, format_provider_class
+from .utterance_handle import UtteranceHandle
 import time
 from .job import get_current_job_context, ObservabilityOptions
 from .event_emitter import EventEmitter
@@ -321,7 +321,7 @@ class AgentSession(EventEmitter[Literal["user_state_changed", "agent_state_chang
                 metrics_collector.set_provider_info("eou", p_class, p_model)
         else:
             if self.pipeline._realtime_model:
-                metrics_collector.set_provider_info("realtime", self.pipeline._realtime_model.__class__.__name__, getattr(self.pipeline._realtime_model, 'model', ''))
+                metrics_collector.set_provider_info("realtime", format_provider_class(self.pipeline._realtime_model), getattr(self.pipeline._realtime_model, 'model', ''))
             if self.pipeline.stt:
                 p_class, p_model = self._get_provider_info(self.pipeline.stt, 'stt')
                 metrics_collector.set_provider_info("stt", p_class, p_model)
@@ -408,10 +408,10 @@ class AgentSession(EventEmitter[Literal["user_state_changed", "agent_state_chang
             return "", ""
         default_model = configs.get(comp_name, {}).get('model', '')
         if hasattr(component, 'active_provider') and component.active_provider is not None:
-            provider_class = component.active_provider.__class__.__name__
+            provider_class = format_provider_class(component.active_provider)
             model = getattr(component.active_provider, 'model', getattr(component.active_provider, 'model_id', getattr(component.active_provider, 'speech_model', getattr(component.active_provider, 'voice_id', getattr(component.active_provider, 'voice', getattr(component.active_provider, 'speaker', default_model))))))
         else:
-            provider_class = component.__class__.__name__
+            provider_class = format_provider_class(component)
             model = getattr(component, 'model', getattr(component, 'model_id', getattr(component, 'speech_model', getattr(component, 'voice_id', getattr(component, 'voice', getattr(component, 'speaker', default_model))))))
         return provider_class, str(model)
 

--- a/videosdk-agents/videosdk/agents/fallback_base.py
+++ b/videosdk-agents/videosdk/agents/fallback_base.py
@@ -4,6 +4,7 @@ import time
 from typing import List, Any, Optional, TYPE_CHECKING
 
 from .metrics import metrics_collector
+from .utils import format_provider_class
 
 logger = logging.getLogger(__name__)
 
@@ -28,8 +29,8 @@ class FallbackBase:
 
     @property
     def active_provider_class(self) -> str:
-        """Return the class name of the currently active provider"""
-        return self.active_provider.__class__.__name__
+        """Return the display class name of the currently active provider"""
+        return format_provider_class(self.active_provider)
 
     @property
     def label(self) -> str:

--- a/videosdk-agents/videosdk/agents/inference/llm.py
+++ b/videosdk-agents/videosdk/agents/inference/llm.py
@@ -188,7 +188,7 @@ class LLM(BaseLLM):
     @staticmethod
     def sarvam(
         *,
-        model_id: str = "sarvam-m",
+        model_id: str = "sarvam-30b",
         config: Optional[Dict] = None,
         temperature: float = 0.7,
         tool_choice: ToolChoice = "auto",
@@ -200,7 +200,7 @@ class LLM(BaseLLM):
         Create an LLM instance configured for Sarvam AI.
 
         Args:
-            model_id: Sarvam model identifier (default: "sarvam-m")
+            model_id: Sarvam model identifier (default: "sarvam-30b")
             config: Optional extra config dict
             temperature: Controls randomness in responses (0.0 to 1.0)
             tool_choice: Tool calling mode ("auto", "required", "none")

--- a/videosdk-agents/videosdk/agents/inference/stt.py
+++ b/videosdk-agents/videosdk/agents/inference/stt.py
@@ -548,10 +548,10 @@ class STT(BaseSTT):
                 logger.info(f"[STT] {text} | Final: {is_final}")
             self._last_transcript = text.strip()
 
-            duration_ms = 0.0
+            duration = 0.0
             if is_final and self._pending_audio_bytes > 0:
                 sample_count = self._pending_audio_bytes / self._bytes_per_sample
-                duration_ms = (sample_count / self._input_sample_rate) * 1000.0
+                duration = sample_count / self._input_sample_rate
                 self._pending_audio_bytes = 0
 
             response = STTResponse(
@@ -562,7 +562,7 @@ class STT(BaseSTT):
                     text=text.strip(),
                     language=language,
                     confidence=confidence,
-                    duration=duration_ms,
+                    duration=duration,
                 ),
                 metadata={
                     "provider": self.provider,

--- a/videosdk-agents/videosdk/agents/inference/stt.py
+++ b/videosdk-agents/videosdk/agents/inference/stt.py
@@ -191,7 +191,7 @@ class STT(BaseSTT):
     @staticmethod
     def sarvam(
         *,
-        model_id: str = "saarika:v2.5",
+        model_id: str = "saaras:v3",
         language: str = "en-IN",
         input_sample_rate: int = 48000,
         output_sample_rate: int = 16000,
@@ -203,7 +203,7 @@ class STT(BaseSTT):
         Create an STT instance configured for Sarvam AI.
 
         Args:
-            model_id: Sarvam model (default: "saarika:v2.5")
+            model_id: Sarvam model (default: "saaras:v3")
             language: Language code (default: "en-IN"). Supports Indian languages.
             input_sample_rate: Input audio sample rate (default: 48000)
             output_sample_rate: Output sample rate for processing (default: 16000)

--- a/videosdk-agents/videosdk/agents/inference/tts.py
+++ b/videosdk-agents/videosdk/agents/inference/tts.py
@@ -150,8 +150,8 @@ class TTS(BaseTTS):
     @staticmethod
     def sarvam(
         *,
-        model_id="bulbul:v2",
-        speaker="anushka",
+        model_id="bulbul:v3",
+        speaker="shubh",
         language="en-IN",
         sample_rate=24000,
         enable_streaming=True,
@@ -163,7 +163,7 @@ class TTS(BaseTTS):
 
         Args:
             model_id: Sarvam model (default: "bulbul:v2")
-            speaker: Speaker voice (default: "anushka")
+            speaker: Speaker voice (default: "shubh")
             language: Language code (default: "en-IN")
             sample_rate: Audio sample rate (default: 24000)
             enable_streaming: Enable streaming mode (default: True)

--- a/videosdk-agents/videosdk/agents/metrics/metrics_collector.py
+++ b/videosdk-agents/videosdk/agents/metrics/metrics_collector.py
@@ -583,7 +583,7 @@ class MetricsCollector:
             stt.stt_latency = stt_latency
             stt.stt_confidence = confidence
             stt.stt_duration = duration
-            logger.info(f"stt latency: {stt_latency}ms | stt confidence: {confidence} | stt duration: {duration}ms")
+            logger.info(f"stt latency: {stt_latency}ms | stt confidence: {confidence} | stt duration: {duration}")
 
         if transcript:
             stt.stt_transcript = transcript

--- a/videosdk-agents/videosdk/agents/pipeline.py
+++ b/videosdk-agents/videosdk/agents/pipeline.py
@@ -23,7 +23,7 @@ from .eou import EOU
 from .denoise import Denoise
 from .voice_mail_detector import VoiceMailDetector
 from .job import get_current_job_context
-from .utils import RealtimeMode,PipelineConfig, build_pipeline_config
+from .utils import RealtimeMode, PipelineConfig, build_pipeline_config, format_provider_class
 from .metrics import metrics_collector
 from .utils import UserState, AgentState
 from .tokenize import (
@@ -612,7 +612,7 @@ class Pipeline(EventEmitter[Literal["start", "error", "transcript_ready", "conte
                 original_pipeline_config["eou"] = {"class": p_class, "model": p_model}
         else:
             if self._realtime_model:
-                original_pipeline_config["realtime"] = {"class": self._realtime_model.__class__.__name__, "model": getattr(self._realtime_model, 'model', '')}
+                original_pipeline_config["realtime"] = {"class": format_provider_class(self._realtime_model), "model": getattr(self._realtime_model, 'model', '')}
             if self.stt:
                 p_class, p_model = get_provider_info(self.stt, 'stt')
                 original_pipeline_config["stt"] = {"class": p_class, "model": p_model}

--- a/videosdk-agents/videosdk/agents/utils.py
+++ b/videosdk-agents/videosdk/agents/utils.py
@@ -742,6 +742,25 @@ class _AudioUtils:
 audio = _AudioUtils()
 
 
+def format_provider_class(obj: Any) -> str:
+    """Display name for a provider component used in metrics.
+
+    Inference components (videosdk.agents.inference.*) carry a `provider`
+    attribute identifying the underlying gateway provider ("deepgram",
+    "google", "cartesia", ...). For those we surface `Videosdk-<provider>`
+    so metrics distinguish the inference path from direct plugin usage.
+    All other components fall back to their actual class name (e.g.
+    `DeepgramSTT`).
+    """
+    if obj is None:
+        return ""
+    cls = obj.__class__
+    provider = getattr(obj, "provider", None)
+    if isinstance(provider, str) and cls.__module__.startswith("videosdk.agents.inference"):
+        return f"Videosdk-{provider}"
+    return cls.__name__
+
+
 async def cancel_and_wait(task: asyncio.Task | None) -> None:
     """Cancel a task and wait for it to finish, suppressing CancelledError."""
     if not task or task.done():


### PR DESCRIPTION
# fix: inference latency units, provider class names, and default models

## Changes

- **STT duration unit fix** — `inference/stt.py` now emits `duration` in seconds instead of milliseconds; misleading `ms` suffix removed from the metrics log line in `metrics_collector.py`.
- **Inference & fallback class name display** — added `format_provider_class()` helper in `utils.py` that returns `Videosdk-<provider>` for inference components and the real class name for direct plugins; wired into `AgentSession`, `Pipeline`, and `FallbackBase` so metrics can distinguish inference-routed components from direct plugin usage.
- **Sarvam default model bumps** in `inference/{llm,stt,tts}.py`:
  - LLM: `sarvam-m` → `sarvam-30b`
  - STT: `saarika:v2.5` → `saaras:v3`
  - TTS: `bulbul:v2` → `bulbul:v3`, default speaker `anushka` → `shubh`
