### PR TITLE
feat: add tts audio cache and agent speech fade-out upon interruption

### DIFF
--- a/examples/cached_tts.py
+++ b/examples/cached_tts.py
@@ -1,0 +1,141 @@
+import asyncio
+import logging
+
+from videosdk.agents import Agent, AgentSession, JobContext, Pipeline, RoomOptions, WorkerJob,  function_tool, TTSAudioCache,InterruptConfig
+from videosdk.plugins.cartesia import CartesiaTTS
+from videosdk.plugins.deepgram import DeepgramSTT
+from videosdk.plugins.google import GoogleLLM
+from videosdk.plugins.silero import SileroVAD
+from videosdk.plugins.turn_detector import TurnDetector, pre_download_model
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+pre_download_model()
+
+
+# --- Fixed phrases: synthesized once, replayed from cache forever after. ---
+GREETING = "Thanks for calling Northwind support. How can I help you today?"
+HOLD = "Sure, let me pull that up for you. One moment."
+GOODBYE = "Thanks for calling Northwind. Have a great day!"
+
+CACHED_PHRASES = [GREETING, HOLD, GOODBYE]
+
+# Stand-in for a real order database.
+_ORDERS = {
+    "1001": {"status": "shipped", "carrier": "UPS", "eta": "Thursday"},
+    "1002": {"status": "processing", "carrier": None, "eta": "next week"},
+    "1003": {"status": "delivered", "carrier": "FedEx", "eta": "delivered Monday"},
+}
+
+
+class SupportAgent(Agent):
+    def __init__(self, tts_cache: TTSAudioCache) -> None:
+        super().__init__(
+            instructions=(
+                "You are Aria, a friendly phone support agent for Northwind, an "
+                "online store. Help callers check order status and connect them to "
+                "a human specialist when they ask. Keep replies short and natural. "
+                "To look up an order, call check_order_status with the order "
+                "number, then tell the caller the result in your own words. If the "
+                "lookup returns found=false, apologize and ask them to double-check the number. "
+            ),
+        )
+        self._cache = tts_cache
+
+    async def on_enter(self) -> None:
+        # Greet from a cached phrase: synthesized once during preload(), then
+        # replayed straight from memory here — no TTS call, instant playback.
+        await self.session.say(GREETING, audio_data=await self._cache.fetch(GREETING))
+
+        # --- Alternative: greet from a pre-recorded audio file -----------------
+        # You can also play a ready-made audio file instead of synthesizing.
+        # load_audio_file() decodes WAV/OGG/MP3/etc. to PCM bytes (no TTS call).
+        # The `message` arg is still required — it is recorded for transcript
+        # and chat context even though the audio is pre-supplied.
+        #
+        # Commented out because this example does not ship an audio file; drop
+        # one next to this script and uncomment to try it:
+        #
+        #   from pathlib import Path
+        #   from videosdk.agents import load_audio_file
+        #
+        #   GREETING_AUDIO = Path(__file__).parent / "greeting.ogg"
+        #   await self.session.say(
+        #       GREETING,
+        #       audio_data=load_audio_file(str(GREETING_AUDIO)),
+        #   )
+
+    async def on_exit(self) -> None:
+        await self.session.say(GOODBYE, audio_data=await self._cache.fetch(GOODBYE))
+
+    @function_tool
+    async def check_order_status(self, order_id: str) -> dict:
+        """Look up the status of a customer's order.
+
+        Args:
+            order_id: The order number the caller provides.
+        """
+        order_id = order_id.strip()
+
+        hold_task = asyncio.create_task(
+            self.session.say(
+                HOLD,
+                audio_data=await self._cache.fetch(HOLD),
+                add_to_chat_context=False,
+            )
+        )
+        order = _ORDERS.get(order_id)
+
+        await hold_task
+
+        if order is None:
+            return {"found": False, "order_id": order_id}
+        return {"found": True, "order_id": order_id, **order}
+
+
+async def start_session(context: JobContext) -> None:
+    # Share one TTS instance between the pipeline and the cache so cached
+    # phrases use the exact same voice as the agent's dynamic speech.
+    tts = CartesiaTTS()
+    tts_cache = TTSAudioCache(tts)
+
+    # Warm every fixed phrase up front. Each preload() entry is one synthesis
+    # now; every fetch() at runtime is then an instant cache hit.
+    await tts_cache.preload(CACHED_PHRASES)
+
+    pipeline = Pipeline(
+        stt=DeepgramSTT(),
+        llm=GoogleLLM(),
+        tts=tts,
+        vad=SileroVAD(),
+        turn_detector=TurnDetector(),
+        # Smooth barge-in: when the caller interrupts, the agent's voice fades
+        # out gradually over `interrupt_fade_duration` seconds instead of being
+        # cut abruptly mid-word. Default is 0.4s; set 0 to disable the fade.
+        interrupt_config=InterruptConfig(interrupt_fade_duration=0.3),
+    )
+
+    session = AgentSession(
+        agent=SupportAgent(tts_cache),
+        pipeline=pipeline,
+    )
+
+    await session.start(wait_for_participant=True, run_until_shutdown=True)
+
+
+def make_context() -> JobContext:
+    return JobContext(
+        room_options=RoomOptions(
+            room_id="<room_id>",
+            name="Northwind Support Agent",
+            playground=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    job = WorkerJob(entrypoint=start_session, jobctx=make_context)
+    job.start()

--- a/videosdk-agents/videosdk/agents/__init__.py
+++ b/videosdk-agents/videosdk/agents/__init__.py
@@ -60,6 +60,7 @@ from .event_emitter import EventEmitter
 from .job import WorkerJob, JobContext, RoomOptions, RecordingOptions, Options, WebSocketConfig, WebRTCConfig, TracesOptions, MetricsOptions, LoggingOptions, ObservabilityOptions
 from .worker import Worker, WorkerOptions, WorkerType
 from .utterance_handle import UtteranceHandle
+from .audio_cache import TTSAudioCache, load_audio_file
 
 # New execution module exports
 from .execution import (
@@ -241,4 +242,6 @@ __all__ = [
     "normalize_lang_code",
     "INDIC_LANGS",
     "pre_warm_tokenizer",
+    "TTSAudioCache",
+    "load_audio_file",
 ]

--- a/videosdk-agents/videosdk/agents/agent_session.py
+++ b/videosdk-agents/videosdk/agents/agent_session.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Callable, Optional, Literal, Awaitable,TYPE_CHECKING
+from typing import Any, AsyncIterator, Callable, Iterable, Optional, Literal, Awaitable, TYPE_CHECKING
 import asyncio
 import uuid
 
@@ -416,12 +416,34 @@ class AgentSession(EventEmitter[Literal["user_state_changed", "agent_state_chang
             model = getattr(component, 'model', getattr(component, 'model_id', getattr(component, 'speech_model', getattr(component, 'voice_id', getattr(component, 'voice', getattr(component, 'speaker', default_model))))))
         return provider_class, str(model)
 
-    async def say(self, message: str, interruptible: bool = True) -> UtteranceHandle:
+    async def say(
+        self,
+        message: str,
+        interruptible: bool = True,
+        audio_data: bytes | bytearray | Iterable[bytes] | AsyncIterator[bytes] | None = None,
+        add_to_chat_context: bool = True,
+    ) -> UtteranceHandle:
         """
         Send an initial message to the agent and return a handle to track it.
         When called from inside a function tool (_is_executing_tool), the current
         turn's utterance is not interrupted or replaced, so the LLM stream can
         continue after the tool returns.
+
+        Args:
+            message: The text being spoken. Always used for transcript/chat
+                context (unless ``add_to_chat_context=False``).
+            interruptible: If False, ``handle.interrupt()`` will raise unless
+                forced.
+            audio_data: Optional pre-synthesized PCM bytes (int16, matching
+                the agent audio track sample rate). When provided, the TTS
+                provider is bypassed and the bytes are streamed straight to
+                the audio track. Accepts a single ``bytes`` blob, an
+                iterable of ``bytes`` chunks, or an async iterator of
+                ``bytes`` chunks. Use ``load_audio_file`` for WAV files or
+                :class:`TTSAudioCache` to cache TTS output by text.
+            add_to_chat_context: When False, the message is spoken but NOT
+                added to the agent's chat history (useful for transient
+                hold messages inside function tools).
         """
         handle = UtteranceHandle(utterance_id=f"utt_{uuid.uuid4().hex[:8]}", interruptible=interruptible)
         self._accept_user_input = True
@@ -434,10 +456,11 @@ class AgentSession(EventEmitter[Literal["user_state_changed", "agent_state_chang
         if traces_flow_manager:
             traces_flow_manager.agent_say_called(message)
 
-        self.agent.chat_context.add_message(role=ChatRole.ASSISTANT, content=message)
+        if add_to_chat_context:
+            self.agent.chat_context.add_message(role=ChatRole.ASSISTANT, content=message)
 
         if hasattr(self.pipeline, 'send_message'):
-            await self.pipeline.send_message(message, handle=handle)
+            await self.pipeline.send_message(message, handle=handle, audio_data=audio_data)
 
         return handle
     

--- a/videosdk-agents/videosdk/agents/audio_cache.py
+++ b/videosdk-agents/videosdk/agents/audio_cache.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+from collections import OrderedDict
+from typing import AsyncIterator, Iterable, TYPE_CHECKING, Union
+
+import av
+from av.audio.resampler import AudioResampler
+
+if TYPE_CHECKING:
+    from .tts.tts import TTS
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_SAMPLE_RATE = 24000
+DEFAULT_NUM_CHANNELS = 1
+
+
+def load_audio_file(
+    path: str,
+    sample_rate: int = DEFAULT_SAMPLE_RATE,
+    num_channels: int = DEFAULT_NUM_CHANNELS,
+) -> bytes:
+    """Load an audio file as raw PCM bytes ready for ``session.say(audio_data=...)``.
+
+    Decodes via libav (PyAV), so any libav-decodable format works: WAV, MP3,
+    Ogg/Vorbis, Ogg/Opus, FLAC, M4A/AAC — and any other codec ffmpeg supports.
+    Resamples and downmixes/upmixes as needed so the output matches the agent
+    audio track format (default 24 kHz, mono, 16-bit signed PCM).
+
+    Args:
+        path: Path to an audio file.
+        sample_rate: Target sample rate in Hz. Must match the agent audio
+            track. Default 24000.
+        num_channels: Target channel count (1 = mono, 2 = stereo). Default 1.
+
+    Returns:
+        Raw little-endian 16-bit signed PCM bytes.
+    """
+    if num_channels not in (1, 2):
+        raise ValueError(f"num_channels must be 1 or 2, got {num_channels}")
+
+    layout = "mono" if num_channels == 1 else "stereo"
+    container = av.open(path)
+    try:
+        stream = next(
+            (s for s in container.streams if s.type == "audio"), None
+        )
+        if stream is None:
+            raise ValueError(f"No audio stream found in {path}")
+
+        resampler = AudioResampler(format="s16", layout=layout, rate=sample_rate)
+        chunks: list[bytes] = []
+        for src_frame in container.decode(stream):
+            for out_frame in resampler.resample(src_frame):
+                chunks.append(out_frame.to_ndarray().tobytes())
+
+        for out_frame in resampler.resample(None):
+            chunks.append(out_frame.to_ndarray().tobytes())
+    finally:
+        container.close()
+
+    return b"".join(chunks)
+
+
+async def _iter_audio_bytes(
+    source: Union[bytes, bytearray, Iterable[bytes], AsyncIterator[bytes]],
+) -> AsyncIterator[bytes]:
+    """Normalize a bytes/iterable/async-iterable audio source into an async chunk stream."""
+    if isinstance(source, (bytes, bytearray)):
+        if source:
+            yield bytes(source)
+        return
+    if hasattr(source, "__aiter__"):
+        async for chunk in source:
+            yield chunk
+        return
+    if hasattr(source, "__iter__"):
+        for chunk in source:
+            yield chunk
+        return
+    raise TypeError(
+        "audio_data must be bytes, Iterable[bytes], or AsyncIterator[bytes]; "
+        f"got {type(source).__name__}"
+    )
+
+
+class TTSAudioCache:
+    """Reuse-by-key cache for TTS-synthesized audio.
+
+    On the first call to :meth:`fetch` for a given phrase, the cache invokes
+    the wrapped TTS instance, collects the PCM bytes, and stores them. All
+    subsequent calls for the same phrase return the stored bytes without
+    touching the TTS provider.
+
+    Eviction is LRU — the least-recently-fetched entry is dropped when the
+    cache exceeds ``max_entries``.
+
+    Example::
+
+        cache = TTSAudioCache(tts)
+        await cache.preload(["Let me check that for you.", "One moment."])
+        await session.say("One moment.", audio_data=await cache.fetch("One moment."))
+    """
+
+    def __init__(self, tts: "TTS", max_entries: int = 128) -> None:
+        if max_entries < 1:
+            raise ValueError("max_entries must be >= 1")
+        self._tts = tts
+        self._max_entries = max_entries
+        self._store: "OrderedDict[str, bytes]" = OrderedDict()
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+    def __contains__(self, text: str) -> bool:
+        return self._key(text, None) in self._store
+
+    def clear(self) -> None:
+        """Drop every entry from the cache."""
+        self._store.clear()
+        self._locks.clear()
+
+    async def fetch(self, text: str, *, voice_id: str | None = None) -> bytes:
+        """Return cached PCM bytes for ``text``, synthesizing on first call.
+
+        Concurrent fetches for the same key share a single synthesis — the
+        second caller awaits the first instead of triggering a duplicate
+        TTS request.
+        """
+        key = self._key(text, voice_id)
+        cached = self._store.get(key)
+        if cached is not None:
+            self._store.move_to_end(key)
+            return cached
+
+        lock = self._locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            cached = self._store.get(key)
+            if cached is not None:
+                self._store.move_to_end(key)
+                return cached
+
+            audio = await self._synthesize(text, voice_id)
+            self._store[key] = audio
+            self._store.move_to_end(key)
+            self._evict_overflow()
+            return audio
+
+    async def preload(
+        self, texts: list[str], *, voice_id: str | None = None
+    ) -> None:
+        """Synthesize and cache a batch of phrases up front (e.g. at startup)."""
+        for text in texts:
+            await self.fetch(text, voice_id=voice_id)
+
+    async def _synthesize(self, text: str, voice_id: str | None) -> bytes:
+        async def _text_iter() -> AsyncIterator[str]:
+            yield text
+
+        kwargs: dict = {}
+        if voice_id is not None:
+            kwargs["voice_id"] = voice_id
+
+        chunks: list[bytes] = []
+        async for chunk in self._tts.stream_synthesize(_text_iter(), **kwargs):
+            if chunk:
+                chunks.append(chunk)
+        return b"".join(chunks)
+
+    def _evict_overflow(self) -> None:
+        while len(self._store) > self._max_entries:
+            evicted_key, _ = self._store.popitem(last=False)
+            self._locks.pop(evicted_key, None)
+
+    @staticmethod
+    def _key(text: str, voice_id: str | None) -> str:
+        payload = f"{voice_id or ''}::{text}".encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()

--- a/videosdk-agents/videosdk/agents/pipeline.py
+++ b/videosdk-agents/videosdk/agents/pipeline.py
@@ -76,6 +76,7 @@ class InterruptConfig:
     interrupt_min_confidence: float = 0.0
     false_interrupt_pause_duration: float = 2.0
     resume_on_false_interrupt: bool = False
+    interrupt_fade_duration: float = 0.4
 
     def __post_init__(self):
         if self.interrupt_min_duration <= 0:
@@ -86,6 +87,8 @@ class InterruptConfig:
             raise ValueError("interrupt_min_confidence must be between 0.0 and 1.0")
         if self.false_interrupt_pause_duration <= 0:
             raise ValueError("false_interrupt_pause_duration must be greater than 0")
+        if self.interrupt_fade_duration < 0:
+            raise ValueError("interrupt_fade_duration must be >= 0")
 
 
 @dataclass
@@ -485,6 +488,7 @@ class Pipeline(EventEmitter[Literal["start", "error", "transcript_ready", "conte
                 interrupt_min_confidence=self.interrupt_config.interrupt_min_confidence,
                 false_interrupt_pause_duration=self.interrupt_config.false_interrupt_pause_duration,
                 resume_on_false_interrupt=self.interrupt_config.resume_on_false_interrupt,
+                interrupt_fade_duration=self.interrupt_config.interrupt_fade_duration,
                 graph_adapter=None,
                 context_window=self.context_window,
                 voice_mail_detector=self.voice_mail_detector,
@@ -546,6 +550,7 @@ class Pipeline(EventEmitter[Literal["start", "error", "transcript_ready", "conte
                 interrupt_min_confidence=self.interrupt_config.interrupt_min_confidence,
                 false_interrupt_pause_duration=self.interrupt_config.false_interrupt_pause_duration,
                 resume_on_false_interrupt=self.interrupt_config.resume_on_false_interrupt,
+                interrupt_fade_duration=self.interrupt_config.interrupt_fade_duration,
                 graph_adapter=self.graph_adapter,
                 context_window=self.context_window,
                 voice_mail_detector=self.voice_mail_detector,

--- a/videosdk-agents/videosdk/agents/pipeline.py
+++ b/videosdk-agents/videosdk/agents/pipeline.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Optional, Callable, Dict, List, Tuple
+from typing import Any, AsyncIterator, Iterable, Literal, Optional, Callable, Dict, List, Tuple, Union
 import asyncio
 import logging
 import av
@@ -969,17 +969,29 @@ class Pipeline(EventEmitter[Literal["start", "error", "transcript_ready", "conte
             except Exception as e:
                 logger.debug(f"TTS prewarm failed (non-fatal): {e}")
     
-    async def send_message(self, message: str, handle: UtteranceHandle) -> None:
+    async def send_message(
+        self,
+        message: str,
+        handle: UtteranceHandle,
+        audio_data: Optional[Union[bytes, bytearray, Iterable[bytes], AsyncIterator[bytes]]] = None,
+    ) -> None:
         """
         Send a message to the pipeline.
-        
+
         Args:
             message: Message text to send
             handle: Utterance handle to track
+            audio_data: Optional pre-synthesized PCM bytes. When provided in
+                cascade mode, bypasses TTS and streams the bytes directly.
+                Ignored in realtime mode (logs a warning).
         """
         self._current_utterance_handle = handle
-        
+
         if self.config.is_realtime:
+            if audio_data is not None:
+                logger.warning(
+                    "audio_data is not supported in realtime mode; falling back to LLM generation"
+                )
             if isinstance(self.llm, RealtimeLLMAdapter):
                 self.llm.current_utterance = handle
                 try:
@@ -989,7 +1001,7 @@ class Pipeline(EventEmitter[Literal["start", "error", "transcript_ready", "conte
                     handle._mark_done()
         else:
             if self.orchestrator:
-                await self.orchestrator.say(message, handle)
+                await self.orchestrator.say(message, handle, audio_data=audio_data)
             else:
                 logger.warning("No orchestrator available")
                 handle._mark_done()

--- a/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
+++ b/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, TYPE_CHECKING, Any, AsyncIterator
+from typing import Iterable, Literal, TYPE_CHECKING, Any, AsyncIterator
 import asyncio
 import uuid
 import logging
@@ -826,13 +826,22 @@ class PipelineOrchestrator(EventEmitter[Literal[
             if self.agent and self.agent.session and self.agent.session.is_background_audio_enabled:
                 await self.agent.session.stop_thinking_audio()
     
-    async def say(self, message: str, handle: UtteranceHandle) -> None:
+    async def say(
+        self,
+        message: str,
+        handle: UtteranceHandle,
+        audio_data: bytes | bytearray | Iterable[bytes] | AsyncIterator[bytes] | None = None,
+    ) -> None:
         """
         Direct TTS synthesis (for initial messages).
 
         Args:
             message: Message to synthesize
             handle: Utterance handle to track
+            audio_data: Optional pre-synthesized PCM bytes. When provided,
+                bypasses TTS synthesis entirely and streams these bytes to
+                the agent audio track. Chunker and TTS text filter are
+                also skipped on this path.
         """
         if not self.speech_generation:
             handle._mark_done()
@@ -847,6 +856,14 @@ class PipelineOrchestrator(EventEmitter[Literal[
         self.speech_generation.on("synthesis_interrupted", _on_playback_done)
 
         try:
+            if audio_data is not None:
+                metrics_collector.set_agent_response(message, emit_transport=True)
+                await self.speech_generation.synthesize_audio_bytes(
+                    audio_data, message, handle=handle
+                )
+                await playback_done.wait()
+                return
+
             if not (self.hooks and self.hooks.has_tts_stream_hook()):
                 tts = self.speech_generation.tts
                 emit = not bool(getattr(tts, "supports_word_timestamps", False))

--- a/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
+++ b/videosdk-agents/videosdk/agents/pipeline_orchestrator.py
@@ -120,6 +120,7 @@ class PipelineOrchestrator(EventEmitter[Literal[
         interrupt_min_confidence: float = 0.0,
         false_interrupt_pause_duration: float = 2.0,
         resume_on_false_interrupt: bool = False,
+        interrupt_fade_duration: float = 0.4,
         graph_adapter: Any | None = None,
         context_window: Any | None = None,
         voice_mail_detector: VoiceMailDetector | None = None,
@@ -151,6 +152,7 @@ class PipelineOrchestrator(EventEmitter[Literal[
         self.interrupt_min_confidence = interrupt_min_confidence
         self.false_interrupt_pause_duration = false_interrupt_pause_duration
         self.resume_on_false_interrupt = resume_on_false_interrupt
+        self.interrupt_fade_duration = interrupt_fade_duration
         
         # Interruption state
         self._generation_id = 0
@@ -240,6 +242,9 @@ class PipelineOrchestrator(EventEmitter[Literal[
         """Set audio track for TTS output"""
         if self.speech_generation:
             self.speech_generation.set_audio_track(audio_track)
+            
+        if audio_track is not None and hasattr(audio_track, "interrupt_fade_duration"):
+            audio_track.interrupt_fade_duration = self.interrupt_fade_duration
     
     def set_voice_mail_detector(self, detector: VoiceMailDetector | None) -> None:
         """Configure voicemail detection"""

--- a/videosdk-agents/videosdk/agents/room/output_stream.py
+++ b/videosdk-agents/videosdk/agents/room/output_stream.py
@@ -52,6 +52,11 @@ class CustomAudioStreamTrack(CustomAudioTrack):
         self._accepting_audio = True
         self._manual_audio_control = False
 
+        # Fade-out on real interruption (seconds). 0 disables the fade and
+        # restores the legacy instant buffer-clear.
+        self.interrupt_fade_duration: float = 0.4
+        self._faded_tail_pending: bool = False
+
         self._samples_played: int = 0
         self._cumulative_input_samples: int = 0
         self._synthesis_start_played: int = 0
@@ -77,12 +82,108 @@ class CustomAudioStreamTrack(CustomAudioTrack):
         return played, pushed
 
 
+    def _frame_to_pcm_bytes(self, frame: AudioFrame) -> bytes:
+        """Extract raw int16 PCM bytes from an AudioFrame built by buildAudioFrames().
+
+        Uses ``to_ndarray()`` (the exact inverse of ``from_ndarray()``) rather
+        than reading ``frame.planes[0]`` directly, since a plane's buffer can be
+        alignment-padded beyond ``samples * sample_width``.
+        """
+        arr = frame.to_ndarray()
+        return arr.astype(np.int16, copy=False).tobytes()
+
+    def _apply_fade_out(self, pcm: bytes) -> bytes:
+        """Apply an exponential fade-out (0 dB → ~-60 dB) to mono int16 PCM.
+
+        Mono assumption (channels == 1): the flat sample array is the per-sample
+        timeline. A multi-channel track would need the ramp repeated per channel.
+        """
+        samples = np.frombuffer(pcm, dtype=np.int16)
+        n = samples.shape[0]
+        if n == 0:
+            return b""
+        t = np.linspace(0.0, 1.0, num=n, dtype=np.float32)
+        gain = np.power(10.0, -3.0 * t, dtype=np.float32) 
+        gain[-1] = 0.0  
+        faded = np.clip(
+            samples.astype(np.float32) * gain,
+            np.iinfo(np.int16).min,
+            np.iinfo(np.int16).max,
+        )
+        return faded.astype(np.int16).tobytes()
+
+    def _collect_pending_pcm(self) -> bytes:
+        """Return the TTS PCM still queued for playback, for fade-out on interrupt.
+
+        The base track keeps it as built AudioFrames in ``frame_buffer`` (and in
+        ``_paused_frames`` while paused). Overridden by mixing tracks, which keep
+        raw bytes in ``audio_data_buffer`` instead.
+        """
+        pending = bytearray()
+        for f in (*self.frame_buffer, *self._paused_frames):
+            try:
+                pending += self._frame_to_pcm_bytes(f)
+            except Exception as e:
+                logger.warning(f"Skipping frame during fade extraction: {e}")
+        return bytes(pending)
+
+    def _load_faded_audio(self, faded_bytes: bytes) -> None:
+        """Re-chunk faded PCM into AudioFrames and queue them in frame_buffer.
+
+        The final partial chunk is zero-padded to chunk_size (it is already near
+        silence at the tail of the fade, so the padding is inaudible).
+        """
+        buf = bytearray(faded_bytes)
+        rem = len(buf) % self.chunk_size
+        if rem:
+            buf += bytes(self.chunk_size - rem)
+        for i in range(0, len(buf), self.chunk_size):
+            try:
+                self.frame_buffer.append(
+                    self.buildAudioFrames(bytes(buf[i : i + self.chunk_size]))
+                )
+            except Exception as e:
+                logger.error(f"Error building faded audio frame: {e}")
+
     def interrupt(self):
-        """Clear all buffers and reset state"""
-        logger.info("Audio track interrupted, clearing buffers.")
+        """Interrupt playback.
+
+        When ``interrupt_fade_duration > 0`` the agent's buffered TTS audio is
+        not cut instantly — a short exponential fade-out tail is kept so the
+        voice ducks gracefully to silence. Otherwise all buffers are cleared
+        immediately (legacy behavior).
+        """
+
+        if self._faded_tail_pending:
+            logger.debug("Audio track interrupt re-entered — faded tail already pending.")
+            self._is_paused = False
+            self._last_speaking_time = 0.0
+            self._synthesis_complete = False
+            self._needs_last_audio_callback = False
+            self._accepting_audio = not self._manual_audio_control
+            return
+
+        pending = b""
+        if self.interrupt_fade_duration and self.interrupt_fade_duration > 0:
+            pending = self._collect_pending_pcm()
+
         self.frame_buffer.clear()
         self.audio_data_buffer.clear()
         self._paused_frames.clear()
+
+        if pending:
+            fade_frames = max(1, round(self.interrupt_fade_duration / AUDIO_PTIME))
+            fade_bytes_len = fade_frames * self.chunk_size
+            faded_tail = self._apply_fade_out(bytes(pending[:fade_bytes_len]))
+            if faded_tail:
+                self._load_faded_audio(faded_tail)
+                self._faded_tail_pending = True
+                logger.info(
+                    f"Audio track interrupted — fading out {len(faded_tail) // self.chunk_size} frame(s)."
+                )
+        else:
+            logger.info("Audio track interrupted, clearing buffers.")
+
         self._is_paused = False
         self._last_speaking_time = 0.0
         self._synthesis_complete = False
@@ -136,6 +237,7 @@ class CustomAudioStreamTrack(CustomAudioTrack):
         """
         self._manual_audio_control = manual_control
         self._accepting_audio = True
+        self._faded_tail_pending = False
         logger.debug(f"Audio input enabled (manual_control={manual_control})")
 
     def on_last_audio_byte(self, callback: Callable[[], Awaitable[None]]) -> None:
@@ -306,8 +408,35 @@ class MixingCustomAudioStreamTrack(CustomAudioStreamTrack):
         self.background_audio_buffer = bytearray()
 
     def interrupt(self):
+        """Interrupt playback.
+
+        The base implementation applies the exponential fade-out — here the
+        overridden ``_collect_pending_pcm`` / ``_load_faded_audio`` make it act
+        on ``audio_data_buffer`` (where this track keeps queued TTS audio).
+        ``background_audio_buffer`` is cleared outright — background audio is
+        never faded.
+        """
         super().interrupt()
         self.background_audio_buffer.clear()
+
+    def _collect_pending_pcm(self) -> bytes:
+        """Mixing tracks build frames just-in-time, so queued TTS audio lives in
+        ``audio_data_buffer`` as raw bytes. ``background_audio_buffer`` is
+        deliberately excluded — background audio is never faded.
+        """
+        return bytes(self.audio_data_buffer)
+
+    def _load_faded_audio(self, faded_bytes: bytes) -> None:
+        """Mixing tracks play from ``audio_data_buffer``; queue the faded tail
+        there. Padded to a chunk_size multiple so recv() fully drains it — a
+        sub-chunk remainder would never be consumed and would leave
+        ``is_speaking`` stuck True.
+        """
+        buf = bytearray(faded_bytes)
+        rem = len(buf) % self.chunk_size
+        if rem:
+            buf += bytes(self.chunk_size - rem)
+        self.audio_data_buffer = buf
 
     async def add_new_bytes(self, audio_data: bytes):
         """Overrides base method to buffer bytes instead of creating frames."""

--- a/videosdk-agents/videosdk/agents/speech_generation.py
+++ b/videosdk-agents/videosdk/agents/speech_generation.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
-from typing import AsyncIterator, Literal, TYPE_CHECKING, Any
+from typing import AsyncIterator, Iterable, Literal, TYPE_CHECKING, Any, Union
 import asyncio
 import logging
 from .event_emitter import EventEmitter
 from .tts.tts import TTS, FlushMarker
 from .utils import UserState, AgentState
 from .metrics import metrics_collector
+from .audio_cache import _iter_audio_bytes
 
 if TYPE_CHECKING:
     from .agent import Agent
     from .room.output_stream import CustomAudioStreamTrack
     from .pipeline_hooks import PipelineHooks
+    from .utterance_handle import UtteranceHandle
 
 logger = logging.getLogger(__name__)
 
@@ -338,7 +340,133 @@ class SpeechGeneration(EventEmitter[Literal["synthesis_started", "first_audio_by
         if last_break <= 0:
             return ""
         return truncated[:last_break].strip()
-    
+
+    async def synthesize_audio_bytes(
+        self,
+        audio_data: Union[bytes, Iterable[bytes], AsyncIterator[bytes]],
+        text: str,
+        handle: "UtteranceHandle | None" = None,
+    ) -> None:
+        """Push pre-synthesized PCM bytes to the audio track, bypassing TTS.
+
+        Emits the same ``synthesis_started`` / ``first_audio_byte`` /
+        ``last_audio_byte`` / ``synthesis_interrupted`` events as
+        :meth:`synthesize`, so downstream listeners (orchestrator,
+        metrics, hooks) keep working without changes.
+
+        Args:
+            audio_data: Raw int16 PCM at the audio track's sample rate.
+                Accepts a single ``bytes`` blob, an iterable of ``bytes``
+                chunks, or an async iterator of ``bytes`` chunks.
+            text: The text being spoken — used for transcripts/metrics
+                even though no synthesis happens.
+            handle: Optional utterance handle; checked between chunks so
+                mid-playback interruption stops the stream promptly.
+        """
+        self._is_interrupted = False
+        self.full_transcript = text
+        self.spoken_transcript = ""
+        self._tier2_spoken_transcript = ""
+
+        if not self.audio_track:
+            if (
+                self.agent
+                and self.agent.session
+                and hasattr(self.agent.session, "pipeline")
+                and hasattr(self.agent.session.pipeline, "audio_track")
+            ):
+                self.audio_track = self.agent.session.pipeline.audio_track
+
+        if not self.audio_track:
+            logger.warning(
+                "No audio track available for cached audio playback"
+            )
+            self.emit("last_audio_byte", {})
+            return
+        
+        if hasattr(self.audio_track, "mark_synthesis_start"):
+            self.audio_track.mark_synthesis_start()
+
+        if hasattr(self.audio_track, "enable_audio_input"):
+            self.audio_track.enable_audio_input(manual_control=True)
+
+        async def _on_last_audio_byte_cb() -> None:
+            metrics_collector.on_agent_speech_end()
+            metrics_collector.complete_turn()
+            if self.agent and self.agent.session:
+                self.agent.session._emit_agent_state(AgentState.IDLE)
+                self.agent.session._emit_user_state(UserState.IDLE)
+                self.agent.session._reply_in_progress = False
+                self.agent.session._reset_wake_up_timer()
+            if self.hooks and self.hooks.has_agent_turn_end_hooks():
+                await self.hooks.trigger_agent_turn_end()
+            logger.info(
+                "Cached audio playback complete - Agent and User set to IDLE"
+            )
+            self.emit("last_audio_byte", {})
+
+        if hasattr(self.audio_track, "on_last_audio_byte"):
+            self.audio_track.on_last_audio_byte(_on_last_audio_byte_cb)
+
+        self.emit("synthesis_started", {})
+        metrics_collector.on_tts_start()
+
+        if self.hooks and self.hooks.has_agent_turn_start_hooks():
+            await self.hooks.trigger_agent_turn_start()
+
+        first_chunk_sent = False
+        try:
+            async for chunk in _iter_audio_bytes(audio_data):
+                if self._is_interrupted or (handle is not None and handle.interrupted):
+                    self.spoken_transcript = self.compute_spoken_transcript()
+                    if hasattr(self.audio_track, "interrupt"):
+                        self.audio_track.interrupt()
+                    self.emit("synthesis_interrupted", {})
+                    return
+                if not chunk:
+                    continue
+                await self.audio_track.add_new_bytes(chunk)
+                if not first_chunk_sent:
+                    first_chunk_sent = True
+                    metrics_collector.on_tts_first_byte()
+                    metrics_collector.on_agent_speech_start()
+                    if self.agent and self.agent.session and self.agent.session.is_background_audio_enabled:
+                        await self.agent.session.stop_thinking_audio()
+                    self.emit("first_audio_byte", {})
+                    if self.agent and self.agent.session:
+                        self.agent.session._emit_agent_state(AgentState.SPEAKING)
+                        self.agent.session._emit_user_state(UserState.LISTENING)
+
+            if hasattr(self.audio_track, "mark_synthesis_complete"):
+                self.audio_track.mark_synthesis_complete()
+
+            if not first_chunk_sent:
+                self.emit("last_audio_byte", {})
+
+            if self.avatar and hasattr(self.avatar, "send_segment_end"):
+                await self.avatar.send_segment_end()
+
+        except asyncio.CancelledError:
+            logger.info("Cached audio playback cancelled")
+            self.emit("synthesis_interrupted", {})
+            raise
+        except Exception as e:
+            logger.error(f"Error during cached audio playback: {e}")
+            self.emit("synthesis_error", {"error": str(e)})
+            raise
+        finally:
+            if (
+                self.agent
+                and self.agent.session
+                and self.agent.session.is_background_audio_enabled
+            ):
+                await self.agent.session.stop_thinking_audio()
+            if self.agent and self.agent.session and self._is_interrupted:
+                self.agent.session._reply_in_progress = False
+                self.agent.session._reset_wake_up_timer()
+            elif self.agent and self.agent.session:
+                self.agent.session._reply_in_progress = False
+
     async def interrupt(self) -> None:
         """Interrupt the current synthesis"""
         self._is_interrupted = True

--- a/videosdk-agents/videosdk/agents/tts/tts.py
+++ b/videosdk-agents/videosdk/agents/tts/tts.py
@@ -136,8 +136,9 @@ class TTS(EventEmitter[Literal["error", "word_spoken"]]):
             Audio bytes
         """
         original_track = self.audio_track
+        original_loop = getattr(self, "loop", None)
         frame_queue = asyncio.Queue()
-        
+
         class QueueTrack:
             def __init__(self):
                 self.hooks = None
@@ -151,9 +152,12 @@ class TTS(EventEmitter[Literal["error", "word_spoken"]]):
                 pass
             def interrupt(self):
                 pass
-                
+
         mock_track = QueueTrack()
         self.audio_track = mock_track
+
+        if original_loop is None:
+            self.loop = asyncio.get_running_loop()
         
         async def synthesize_task():
             try:
@@ -183,6 +187,8 @@ class TTS(EventEmitter[Literal["error", "word_spoken"]]):
                         
         finally:
             self.audio_track = original_track
+            if original_loop is None:
+                self.loop = None
             if not task.done():
                 task.cancel()
 


### PR DESCRIPTION
## feat(TTS Audio Cache): add pre-supplied audio playback with TTS cache

- Add an optional `audio_data` parameter to `session.say()` that streams
  pre-synthesized PCM straight to the agent audio track, skipping the TTS
  provider — useful for fixed phrases.

New `audio_cache` module:
- `TTSAudioCache` — synthesizes a phrase once, holds the PCM bytes in an
  in-memory LRU store, replays by text key on subsequent calls.
- `load_audio_file()` — decodes any libav format to playback-ready PCM.

### Usage

```python
from videosdk.agents import TTSAudioCache, load_audio_file

tts = CartesiaTTS()
cache = TTSAudioCache(tts)
await cache.preload(["Thanks for calling. How can I help?"])  # synthesize once

# Replay from cache — no TTS call, instant playback
await session.say(
    "Thanks for calling. How can I help?",
    audio_data=await cache.fetch("Thanks for calling. How can I help?"),
)

# Or play a ready-made audio file
await session.say(
    "Thanks for calling. How can I help?",
    audio_data=load_audio_file("greeting.ogg"),
)

```
## feat TTS  Fade Out : add graceful Interruption handling for agent speech

- When a user interrupts the agent, the buffered TTS audio is now ducked to silence with a short exponential fade-out instead of being cut mid-sample, so interruptions feel natural.

Enabled by default; tune or disable via InterruptConfig:

```python
    Pipeline(
        ...,
        interrupt_config=InterruptConfig(interrupt_fade_duration=0.2),
    )
```

- interrupt_fade_duration is in seconds (default 0.4); 0 restores the legacy instant buffer-clear.
- Framework-level and provider-independent — no TTS plugin changes


